### PR TITLE
Force rollout from a failing state

### DIFF
--- a/Charts/ioc-instance/templates/deployment.yaml
+++ b/Charts/ioc-instance/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     is_ioc: "true"
 spec:
   replicas: 1
+  podManagementPolicy: Parallel  # force rollout from a failing state
   selector:
     matchLabels:
       app: {{ .Release.Name }}
@@ -20,7 +21,7 @@ spec:
         ioc_group: {{ .Values.ioc_group }}
         is_ioc: "true"
       annotations:
-        rollme: {{ randAlphaNum 5 | quote }}  # force roll out
+        rollme: {{ randAlphaNum 5 | quote }}  # force roll out for config changes
     spec:
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName | quote }}


### PR DESCRIPTION
If the pods are in a failing state (maybe bad image version for example), then doing an `ec deploy` updates the helm application but the pods do not update (https://github.com/kubernetes/kubernetes/issues/67250)

A suggested fix in the issue is to set `podManagementPolicy: Parallel` - which I have successfully tested on `ec deploy`

One thing to note is that this update will require a manual delete and deploy as per https://github.com/kubernetes/kubernetes/issues/117693