### PR TITLE
Create seperate services, iocs maps

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -1,5 +1,5 @@
 {{- define "ec-helm-charts.argocd-apps" -}}
-{{- range $index, $services := list .Values.iocs .Values.services }}
+{{- range $index, $services := list .Values.ec_services .Values.services }}
 {{- range $service, $settings := $services }}
 {{- /* Make sure settings is an empty dict if it is currently nil */ -}}
 {{ $settings := default dict $settings -}}
@@ -10,7 +10,7 @@ metadata:
   name: {{ $service }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    is_ioc: {{ eq $index 0 | ternary true false | quote }}
+    ec_service: {{ eq $index 0 | ternary true false | quote }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -10,7 +10,7 @@ metadata:
   name: {{ $service }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    ec_service: {{ eq $index 0 | ternary true false | quote }}
+    is_ioc: {{ eq $index 0 | ternary true false | quote }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -24,9 +24,11 @@ spec:
     targetRevision: {{ default $.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3
+      {{- if eq $index 0 }}
       parameters:
         - name: global.enabled
           value: {{ eq $settings.enabled false | ternary false true | quote }}
+      {{- end }}
       valueFiles:
         - ../values.yaml
         - values.yaml

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -1,6 +1,6 @@
 {{- define "ec-helm-charts.argocd-apps" -}}
-{{- $currentScope := . -}}
-{{- range $service, $settings := .Values.services }}
+{{- range $index, $services := list .Values.iocs .Values.services }}
+{{- range $service, $settings := $services }}
 {{- /* Make sure settings is an empty dict if it is currently nil */ -}}
 {{ $settings := default dict $settings -}}
 {{ if ne $settings.removed true }}
@@ -8,20 +8,20 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ $service }}
-  namespace: {{ $currentScope.Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    ec_service: {{ eq $settings.ec_service true | ternary true false | quote }}
+    ec_service: {{ eq $index 0 | ternary true false | quote }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: {{ default $currentScope.Release.Namespace $currentScope.Values.project }}
+  project: {{ default $.Release.Namespace $.Values.project }}
   destination:
-    namespace: {{ $currentScope.Values.destination.namespace }}
-    name: {{ $currentScope.Values.destination.name }}
+    namespace: {{ $.Values.destination.namespace }}
+    name: {{ $.Values.destination.name }}
   source:
-    repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
+    repoURL: {{ default $.Values.source.repoURL $settings.repoURL }}
     path: services/{{ $service }}
-    targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
+    targetRevision: {{ default $.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3
       parameters:
@@ -39,6 +39,7 @@ spec:
       - ApplyOutOfSyncOnly=true
       - RespectIgnoreDifferences=true
 ---
-{{ end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Changes the expected format of the values.yaml so that the labeling of `ec-service` can be done in the background and clear separation between services that may have enabling/disabling implemented
```
services:
  epics-pvcs:
  epics-opis:

iocs:
  b01-1-ea-test-01:
    targetRevision: 2024.9.1
```

Additional optimisation:
- Replace `$currentScope` for just `$`