### PR TITLE
Add additional volumes & volume mounts, fix schema

### DIFF
--- a/Charts/ioc-instance/templates/deployment.yaml
+++ b/Charts/ioc-instance/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ .Release.Name }}-config
+        {{- if .Values.volumes }}
+{{  toYaml .Values.volumes | indent 8}}
+        {{- end }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ .Values.image }}
@@ -114,6 +117,9 @@ spec:
         - name: autosave-volume
           mountPath: /autosave
           subPath: "{{ .Release.Name }}"
+        {{- if .Values.volumeMounts }}
+{{  toYaml .Values.volumeMounts | indent 8}}
+        {{- end }}
         stdin: true
         tty: true
         securityContext:

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -83,11 +83,25 @@ runtimeClaim: ""
 # use the shared PVC autosave files (comment out for no autosave)
 autosaveClaim: ""
 
+# Additional volumes for the IOC pod
+volumes: []
+# - name:
+#   hostPath:
+#     path:
+# - name:
+#   persistentVolumeClaim:
+#     claimName:
+
+# Additional volume mounts for the IOC container
+volumeMounts: []
+# - name:
+#   mountPath:
+
 # nodeName is used to run on a specific node. Overrides affinity
 nodeName: ""
 
 # Affinity is a group of affinity scheduling rules.
-affinity:
+affinity: {}
   # nodeAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:
   #     nodeSelectorTerms:

--- a/Schemas/ioc-instance.schema.json
+++ b/Schemas/ioc-instance.schema.json
@@ -10,6 +10,12 @@
     "base": {
       "type": "object",
       "properties": {
+        "image": {
+          "type": "string",
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/image",
+          "description": "The container image URI for the Generic IOC",
+          "default": ""
+        },
         "location": {
           "type": "string",
           "description": "The location where the IOCs will run",
@@ -26,16 +32,6 @@
         "hostNetwork": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/hostNetwork",
           "description": "Use host network for IOC - required for Channel Access to work outside of the cluster unless a ca-gateway is in use"
-        },
-        "affinity": {
-          "description": "Affinity is a group of affinity scheduling rules.",
-          "oneOf": [
-            {"type": "null"},
-            {"$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/affinity"}
-          ]
-        },
-        "nodeName": {
-          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeName"
         },
         "iocFolder": {
           "type": "string",
@@ -78,12 +74,6 @@
         "securityContext": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/securityContext"
         },
-        "image": {
-          "type": "string",
-          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/image",
-          "description": "The container image URI for the Generic IOC",
-          "default": ""
-        },
         "dataVolume": {
           "type": "object",
           "description": "A volume to mount for writing data to. This can be a PVC or a hostPath",
@@ -112,15 +102,23 @@
           "type": "string",
           "description": "Use the shared PVC autosave files (exclude for no autosave)"
         },
-        "resources": {
-          "description": "ResourceRequirements describes the compute resource requirements.",
-          "oneOf": [
-              {"type": "null"},
-              {"$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/resources"}
-          ]
+        "volumes": {
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/volumes"
+        },
+        "volumeMounts": {
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/volumeMounts"
+        },
+        "nodeName": {
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeName"
+        },
+        "affinity": {
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/affinity"
         },
         "tolerations": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations"
+        },
+        "resources": {
+          "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/resources"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
- Allow arbitrary addition of volumes attached to the IOC pod
- Allow arbitrary addition of container volume mounted to IOC container
- Update schema to reflect above (point to k8s schemas)
- Reorder schema to match the order of the default values.yaml
- Give affinity a default of `{}` in order to remove `{"type": "null"}` which then forces a manual definition of `description`
- Remove `{"type": "null"},` for resources as already has a default