### PR TITLE
Add missing globals dictionary to schema

### DIFF
--- a/Schemas/ioc-instance.schema.json
+++ b/Schemas/ioc-instance.schema.json
@@ -121,6 +121,23 @@
         },
         "tolerations": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations"
+        },
+        "global": {
+          "type": "object",
+          "description": "Shared values for all services. Globals are passed to all subcharts",
+          "properties": {
+            "location": {
+              "$ref": "#/$defs/base/properties/location"
+            },
+            "ioc_group": {
+              "$ref": "#/$defs/base/properties/ioc_group"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Set to true to start a service",
+              "default": "true"
+            }
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
For the `globals` dictionary, this still allows `additionalProperties` to be added  - which means that you could accidentally include "enable" rather than "enabled" for example. However, since globals are passed to subcharts - there may be legitimate arbitrary globals passed that we have not considered. Im open to adding `"additionalProperties": false` because it would give a better hint during validation, but opting out of CI would be needed for adding arbitrary globals