### PR TITLE
Apply chart title

### DIFF
--- a/.github/workflows/schema_release.yml
+++ b/.github/workflows/schema_release.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Set schema versions
+        run: |
+          if [ "${GITHUB_REF_TYPE}" == "tag" ] ; then
+            TAG=${GITHUB_REF_NAME}
+            for schema in Schemas/*.schema.json; do
+            (
+                sed -i 's/0.0.0-b0/'"$TAG"'/' $schema
+            )
+            done
+          fi
       - name: Github Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:

--- a/Schemas/argocd-apps.schema.json
+++ b/Schemas/argocd-apps.schema.json
@@ -68,7 +68,7 @@
         "services",
         "ec-services"
     ],
-    "title": "argocd-apps 0.0.1",
+    "title": "argocd-apps 0.0.0-b0",
     "type": "object"
 }
   

--- a/Schemas/argocd-apps.schema.json
+++ b/Schemas/argocd-apps.schema.json
@@ -68,7 +68,7 @@
         "services",
         "ec-services"
     ],
-    "title": "Values",
+    "title": "argocd-apps 0.0.1",
     "type": "object"
 }
   

--- a/Schemas/ioc-instance.schema.json
+++ b/Schemas/ioc-instance.schema.json
@@ -1,5 +1,5 @@
 {
-  "title": "Values",
+  "title": "ioc-instance 0.0.1",
   "type": "object",
   "$schema": "http://json-schema.org/schema#",
   "$ref": "#/$defs/service",

--- a/Schemas/ioc-instance.schema.json
+++ b/Schemas/ioc-instance.schema.json
@@ -1,5 +1,5 @@
 {
-  "title": "ioc-instance 0.0.1",
+  "title": "ioc-instance 0.0.0-b0",
   "type": "object",
   "$schema": "http://json-schema.org/schema#",
   "$ref": "#/$defs/service",


### PR DESCRIPTION
Setting the title of the json schema can give a useful indication from the hints what version is referred to. This supports cases where we might point to the `latest` schema rather than a specific schema such as: https://github.com/epics-containers/ec-helm-charts/releases/latest/download/ioc-instance.schema.json

This feature can be tested by adding `# yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/4.1.4%2Bb1/ioc-instance.schema.json` into a yaml file and getting type hinting with vscode yaml-language server extension