### PR TITLE
Support array for entrypoint

### DIFF
--- a/Charts/ioc-instance/templates/deployment.yaml
+++ b/Charts/ioc-instance/templates/deployment.yaml
@@ -82,20 +82,38 @@ spec:
       - name: {{ .Release.Name }}
         image: {{ .Values.image }}
         command:
-          - {{ .Values.startCommand }}
+        {{- if (kindIs "string" .Values.startCommand) }}
+        - {{ .Values.startCommand }}
+        {{- else if (kindIs "slice" .Values.startCommand) }}
+        {{- .Values.startCommand | toYaml | nindent 8 }}
+        {{- end }}
         args:
-          - {{ .Values.startArgs }}
+        {{- if (kindIs "string" .Values.startArgs) }}
+        - {{ .Values.startArgs }}
+        {{- else if (kindIs "slice" .Values.startArgs) }}
+        {{- .Values.startArgs | toYaml | nindent 8 }}
+        {{- end }}
         livenessProbe:
           exec:
             command:
+            {{- if (kindIs "string" .Values.liveness) }}
             - /bin/bash
             - {{ .Values.liveness }}
+            {{- else if (kindIs "slice" .Values.liveness) }}
+            {{- .Values.liveness | toYaml | nindent 12 }}
+            {{- end }}
           initialDelaySeconds: 120
           periodSeconds: 10
         lifecycle:
           preStop:
             exec:
-              command: ["bash", "-c", "{{ .Values.stop }}"]
+              command:
+              {{- if (kindIs "string" .Values.stop) }}
+              - /bin/bash
+              - {{ .Values.stop }}
+              {{- else if (kindIs "slice" .Values.stop) }}
+              {{- .Values.stop | toYaml | nindent 14 }}
+              {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: {{ .Values.iocConfig }}

--- a/Schemas/ioc-instance.schema.json
+++ b/Schemas/ioc-instance.schema.json
@@ -44,24 +44,56 @@
           "default": "/epics/ioc/config"
         },
         "startCommand": {
-          "type": "string",
-          "description": "The command run as the entry point of the container.",
-          "default": "bash"
+          "description": "The command to run as the entry point of the container.",
+          "default": "bash",
+          "oneOf":[
+            {
+            "type": "string"
+            },
+            {
+            "type": "array",
+            "items": { "type": "string" }
+            }
+          ]
         },
         "startArgs": {
-          "type": "string",
           "description": "The arguments for the entry point of the container.",
-          "default": "/epics/ioc/start.sh"
+          "default": "/epics/ioc/start.sh",
+          "oneOf":[
+            {
+            "type": "string"
+            },
+            {
+            "type": "array",
+            "items": { "type": "string" }
+            }
+          ]
         },
         "stop": {
-          "type": "string",
           "description": "Script run before stopping the IOC",
-          "default": "/epics/ioc/stop.sh"
+          "default": "/epics/ioc/stop.sh",
+          "oneOf":[
+            {
+            "type": "string"
+            },
+            {
+            "type": "array",
+            "items": { "type": "string" }
+            }
+          ]
         },
         "liveness": {
-          "type": "string",
-          "description": "Script for determining the liveness of the IOC",
-          "default": "/epics/ioc/liveness.sh"
+          "description": "A bash script for determining the liveness of the IOC or list of commands",
+          "default": "/epics/ioc/liveness.sh",
+          "oneOf":[
+            {
+            "type": "string"
+            },
+            {
+            "type": "array",
+            "items": { "type": "string" }
+            }
+          ]
         },
         "globalEnv": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/env",


### PR DESCRIPTION
This allows the current command entrypoints to also be able to pass an array of commands/args. This should allow deployments like as the panda-ioc to not be forced to create scripts for entry.

I test this on at Diamond on b01-1 using bl01c-ea-flip-01 https://gitlab.diamond.ac.uk/controls/containers/beamline/b01-1-services/-/commit/d591de8f8427d9fe6228af2d4bc033ebaa795fa4