### PR TITLE
allow rollme to be a commit hash for ArgoCD deployed IOCs

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -28,6 +28,9 @@ spec:
       parameters:
         - name: global.enabled
           value: {{ eq $settings.enabled false | ternary false true | quote }}
+        # pass the synced commit hash as a global value
+        - name: global.commitHash
+          value: $ARGOCD_APP_REVISION
       {{- end }}
       valueFiles:
         - ../values.yaml

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -30,7 +30,7 @@ spec:
           value: {{ eq $settings.enabled false | ternary false true | quote }}
         # pass the synced commit hash as a global value
         - name: global.commitHash
-          value: $ARGOCD_APP_REVISION
+          value: $ARGOCD_APP_REVISION_SHORT
       {{- end }}
       valueFiles:
         - ../values.yaml

--- a/Charts/ioc-instance/templates/deployment.yaml
+++ b/Charts/ioc-instance/templates/deployment.yaml
@@ -36,8 +36,9 @@ spec:
         location: {{ $location }}
         ioc_group: {{ $ioc_group }}
         is_ioc: "true"
-        # always re-deploy in case the configMap has changed
-        rollme: {{ randAlphaNum 5 | quote }}
+        # re-deploy in case the configMap has changed - use a random value
+        # unless the Commit Hash is supplied (by ArgoCD or helm command line)
+        rollme: {{ .Values.global.commitHash | default (randAlphaNum 5) | quote }}
     spec:
       {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . }}
@@ -66,11 +67,13 @@ spec:
         - name: {{ .Release.Name }}-data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-data
-        {{- else with .Values.dataVolume.hostPath }}
+        {{- else }}
+        {{- with .Values.dataVolume.hostPath }}
         - name: {{ .Release.Name }}-data
           hostPath:
             path: {{ . }}
             type: Directory
+        {{- end }}
         {{- end }}
         - name: config-volume
           configMap:

--- a/Charts/ioc-instance/templates/deployment.yaml
+++ b/Charts/ioc-instance/templates/deployment.yaml
@@ -174,9 +174,11 @@ spec:
         {{- end }}
       {{- with .Values.nodeName }}
       nodeName: {{ . }}
-      {{- else with .Values.affinity }}
+      {{- else }}
+      {{- with .Values.affinity }}
       affinity:
 {{  toYaml . | indent 8}}
+      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
switch rollme to use a commit hash instead of a random value

- ioc-instance: 
  - use .Values.commitHash if it is set 
  - or continue to use a random value if commitHash is not set
- argocd-apps:
  - pass down  pass this down $ARGOCD_APP_REVISION_SHORT as commitHash value