### PR TITLE
restore ioc-instance namespace to ioc-instance library chart

### DIFF
--- a/Charts/ioc-instance/templates/_configmap.tpl
+++ b/Charts/ioc-instance/templates/_configmap.tpl
@@ -1,7 +1,7 @@
-{{- define "iocInstance.configmap" -}}
-{{- $_ := set .Values.iocInstance "configFolderConfigMap" (.Files.Glob "config/*").AsConfig -}}
-{{- $_ := set .Values.iocInstance "configFolderHash" (.Values.iocInstance.configFolderConfigMap | sha1sum) -}}
-{{ if ne .Values.iocInstance.configFolderConfigMap "{}" }}
+{{- define "ioc-instance.configmap" -}}
+{{- $_ := set .Values "configFolderConfigMap" (.Files.Glob "config/*").AsConfig -}}
+{{- $_ := set .Values "configFolderHash" (.Values.configFolderConfigMap | sha1sum) -}}
+{{ if ne .Values.configFolderConfigMap "{}" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +10,6 @@ metadata:
     app: {{ .Release.Name }}
 # contents of the ioc instance config folder
 data:
-{{ .Values.iocInstance.configFolderConfigMap | indent 2 }}
+{{ .Values.configFolderConfigMap | indent 2 }}
 {{ end -}}
 {{- end -}}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -1,6 +1,6 @@
-{{ define "iocInstance" }}
+{{ define "ioc-instance" }}
 
-{{- include "iocInstance.configmap" . }}
+{{- include "ioc-instance.configmap" . }}
 ---
 {{ include "ioc-instance.statefulset" . }}
 ---

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -2,8 +2,8 @@
 
 {{- include "iocInstance.configmap" . }}
 ---
-{{ include "iocInstance.statefulset" . }}
+{{ include "ioc-instance.statefulset" . }}
 ---
-{{ include "iocInstance.service" . }}
+{{ include "ioc-instance.service" . }}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,7 +1,7 @@
 {{- define "ioc-instance.service" -}}
 
-{{/* Use with, set to move the iocInstance namespace to the root namespace. */}}
-{{ with .Values.iocInstance }}
+{{/* Use with, set to move the ioc-instance namespace to the root namespace. */}}
+{{ with get .Values "ioc-instance" }}
 {{- $_ := set . "Values" . -}}
 
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
@@ -57,5 +57,5 @@ spec:
       protocol: UDP
 {{- end }} {{/* end if not .Values.hostNetwork */}}
 
-{{- end -}} {{/* end with .Values.iocInstance */}}
+{{- end -}} {{/* end with .Values.ioc-instance */}}
 {{- end -}} {{/* end define "statefulset" */}}

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,12 +1,14 @@
 {{- define "ioc-instance.service" -}}
 
-{{/* Use with, set to move the ioc-instance namespace to the root namespace. */}}
+{{/*
+  Use with to access ioc-instance key.
+  Required because .ioc-instance is illegal because of the hyphen.
+*/}}
 {{ with get .Values "ioc-instance" }}
-{{- $_ := set . "Values" . -}}
 
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
 # TODO - we could introduce this service to hostNetwork IOCs too: for review.
-{{- if not .Values.hostNetwork }}
+{{- if not .hostNetwork }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,16 +22,16 @@ spec:
   selector:
     app: {{ $.Release.Name }}
   type: ClusterIP
-  {{- $alloc_args := dict "name" $.Release.Name "namespace" $.Release.Namespace "baseIp" .Values.baseIp "startIp" .Values.startIp }}
-  clusterIP: {{ .Values.clusterIP | default (include "allocateIpFromName" $alloc_args) }}
+  {{- $alloc_args := dict "name" $.Release.Name "namespace" $.Release.Namespace "baseIp" .baseIp "startIp" .startIp }}
+  clusterIP: {{ .clusterIP | default (include "allocateIpFromName" $alloc_args) }}
   ports:
     - name: ca-server-tcp
-      port: {{ .Values.ca_server_port | default 5064 }}
-      targetPort: {{ .Values.ca_server_port | default 5064 }}
+      port: {{ .ca_server_port | default 5064 }}
+      targetPort: {{ .ca_server_port | default 5064 }}
       protocol: TCP
     - name: ca-server-udp
-      port: {{ .Values.ca_server_port | default 5064 }}
-      targetPort: {{ .Values.ca_server_port | default 5064 }}
+      port: {{ .ca_server_port | default 5064 }}
+      targetPort: {{ .ca_server_port | default 5064 }}
       protocol: UDP
     - name: ca-repeater-tcp
       port: {{ add1 (.Values.ca_server_port | default 5064) }}
@@ -40,12 +42,12 @@ spec:
       targetPort: {{ add1 (.Values.ca_server_port | default 5064) }}
       protocol: UDP
     - name: pva-server-tcp
-      port: {{ .Values.pva_server_port | default 5075 }}
-      targetPort: {{ .Values.pva_server_port | default 5075 }}
+      port: {{ .pva_server_port | default 5075 }}
+      targetPort: {{ .pva_server_port | default 5075 }}
       protocol: TCP
     - name: pva-server-udp
-      port: {{ .Values.pva_server_port | default 5075 }}
-      targetPort: {{ .Values.pva_server_port | default 5075 }}
+      port: {{ .pva_server_port | default 5075 }}
+      targetPort: {{ .pva_server_port | default 5075 }}
       protocol: UDP
     - name: pva-broadcast-tcp
       port: {{ add1 (.Values.pva_server_port | default 5075) }}
@@ -55,7 +57,7 @@ spec:
       port: {{ add1 (.Values.pva_server_port | default 5075) }}
       targetPort: {{ add1 (.Values.pva_server_port | default 5075) }}
       protocol: UDP
-{{- end }} {{/* end if not .Values.hostNetwork */}}
+{{- end }} {{/* end if not .hostNetwork */}}
 
-{{- end -}} {{/* end with .Values.ioc-instance */}}
+{{- end -}} {{/* end with .ioc-instance */}}
 {{- end -}} {{/* end define "statefulset" */}}

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -34,12 +34,12 @@ spec:
       targetPort: {{ .ca_server_port | default 5064 }}
       protocol: UDP
     - name: ca-repeater-tcp
-      port: {{ add1 (.Values.ca_server_port | default 5064) }}
-      targetPort: {{ add1 (.Values.ca_server_port | default 5064) }}
+      port: {{ add1 (.caServerPort | default 5064) }}
+      targetPort: {{ add1 (.caServerPort | default 5064) }}
       protocol: TCP
     - name: ca-repeater-udp
-      port: {{ add1 (.Values.ca_server_port | default 5064) }}
-      targetPort: {{ add1 (.Values.ca_server_port | default 5064) }}
+      port: {{ add1 (.caServerPort | default 5064) }}
+      targetPort: {{ add1 (.caServerPort | default 5064) }}
       protocol: UDP
     - name: pva-server-tcp
       port: {{ .pva_server_port | default 5075 }}
@@ -50,12 +50,12 @@ spec:
       targetPort: {{ .pva_server_port | default 5075 }}
       protocol: UDP
     - name: pva-broadcast-tcp
-      port: {{ add1 (.Values.pva_server_port | default 5075) }}
-      targetPort: {{ add1 (.Values.pva_server_port | default 5075) }}
+      port: {{ add1 (.pvaServerPort | default 5075) }}
+      targetPort: {{ add1 (.pvaServerPort | default 5075) }}
       protocol: TCP
     - name: pva-broadcast-udp
-      port: {{ add1 (.Values.pva_server_port | default 5075) }}
-      targetPort: {{ add1 (.Values.pva_server_port | default 5075) }}
+      port: {{ add1 (.pvaServerPort | default 5075) }}
+      targetPort: {{ add1 (.pvaServerPort | default 5075) }}
       protocol: UDP
 {{- end }} {{/* end if not .hostNetwork */}}
 

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,55 +1,61 @@
-{{- define "iocInstance.service" -}}
+{{- define "ioc-instance.service" -}}
+
+{{/* Use with, set to move the iocInstance namespace to the root namespace. */}}
+{{ with .Values.iocInstance }}
+{{- $_ := set . "Values" . -}}
+
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
 # TODO - we could introduce this service to hostNetwork IOCs too: for review.
-{{- if not .Values.iocInstance.hostNetwork }}
+{{- if not .Values.hostNetwork }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $.Release.Name }}
   labels:
-    app: {{ .Release.Name }}
-    location: {{ .Values.global.location }}
-    ioc_group: {{ .Values.global.ioc_group }}
+    app: {{ $.Release.Name }}
+    location: {{ $.Values.global.location }}
+    ioc_group: {{ $.Values.global.ioc_group }}
     is_ioc: "true"
 spec:
   selector:
-    app: {{ .Release.Name }}
+    app: {{ $.Release.Name }}
   type: ClusterIP
-  {{- $alloc_args := dict "name" .Release.Name "namespace" .Release.Namespace "baseIp" .Values.iocInstance.baseIp "startIp" .Values.iocInstance.startIp }}
-  clusterIP: {{ .Values.iocInstance.clusterIP | default (include "allocateIpFromName" $alloc_args) }}
+  {{- $alloc_args := dict "name" $.Release.Name "namespace" $.Release.Namespace "baseIp" .Values.baseIp "startIp" .Values.startIp }}
+  clusterIP: {{ .Values.clusterIP | default (include "allocateIpFromName" $alloc_args) }}
   ports:
     - name: ca-server-tcp
-      port: {{ .Values.iocInstance.ca_server_port | default 5064 }}
-      targetPort: {{ .Values.iocInstance.ca_server_port | default 5064 }}
+      port: {{ .Values.ca_server_port | default 5064 }}
+      targetPort: {{ .Values.ca_server_port | default 5064 }}
       protocol: TCP
     - name: ca-server-udp
-      port: {{ .Values.iocInstance.ca_server_port | default 5064 }}
-      targetPort: {{ .Values.iocInstance.ca_server_port | default 5064 }}
+      port: {{ .Values.ca_server_port | default 5064 }}
+      targetPort: {{ .Values.ca_server_port | default 5064 }}
       protocol: UDP
     - name: ca-repeater-tcp
-      port: {{ add1 (.Values.iocInstance.ca_server_port | default 5064) }}
-      targetPort: {{ add1 (.Values.iocInstance.ca_server_port | default 5064) }}
+      port: {{ add1 (.Values.ca_server_port | default 5064) }}
+      targetPort: {{ add1 (.Values.ca_server_port | default 5064) }}
       protocol: TCP
     - name: ca-repeater-udp
-      port: {{ add1 (.Values.iocInstance.ca_server_port | default 5064) }}
-      targetPort: {{ add1 (.Values.iocInstance.ca_server_port | default 5064) }}
+      port: {{ add1 (.Values.ca_server_port | default 5064) }}
+      targetPort: {{ add1 (.Values.ca_server_port | default 5064) }}
       protocol: UDP
     - name: pva-server-tcp
-      port: {{ .Values.iocInstance.pva_server_port | default 5075 }}
-      targetPort: {{ .Values.iocInstance.pva_server_port | default 5075 }}
+      port: {{ .Values.pva_server_port | default 5075 }}
+      targetPort: {{ .Values.pva_server_port | default 5075 }}
       protocol: TCP
     - name: pva-server-udp
-      port: {{ .Values.iocInstance.pva_server_port | default 5075 }}
-      targetPort: {{ .Values.iocInstance.pva_server_port | default 5075 }}
+      port: {{ .Values.pva_server_port | default 5075 }}
+      targetPort: {{ .Values.pva_server_port | default 5075 }}
       protocol: UDP
     - name: pva-broadcast-tcp
-      port: {{ add1 (.Values.iocInstance.pva_server_port | default 5075) }}
-      targetPort: {{ add1 (.Values.iocInstance.pva_server_port | default 5075) }}
+      port: {{ add1 (.Values.pva_server_port | default 5075) }}
+      targetPort: {{ add1 (.Values.pva_server_port | default 5075) }}
       protocol: TCP
     - name: pva-broadcast-udp
-      port: {{ add1 (.Values.iocInstance.pva_server_port | default 5075) }}
-      targetPort: {{ add1 (.Values.iocInstance.pva_server_port | default 5075) }}
+      port: {{ add1 (.Values.pva_server_port | default 5075) }}
+      targetPort: {{ add1 (.Values.pva_server_port | default 5075) }}
       protocol: UDP
-{{- end }}
+{{- end }} {{/* end if not .Values.hostNetwork */}}
 
-{{- end -}}
+{{- end -}} {{/* end with .Values.iocInstance */}}
+{{- end -}} {{/* end define "statefulset" */}}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -1,25 +1,30 @@
-{{- define "iocInstance.statefulset" -}}
+{{- define "ioc-instance.statefulset" -}}
+
+
+{{/* Use with, set to move the iocInstance namespace to the root namespace. */}}
+{{ with .Values.iocInstance }}
+{{- $_ := set . "Values" . -}}
+
 {{- /*
 Default the derivable substitution values.
 
 This keeps the length of the values.txt file for each individual IOC
 to a minimum
 */ -}}
-{{- $location := default .Values.global.location .Values.iocInstance.location | required "ERROR - You must supply location or global.location" -}}
-{{- $ioc_group := default .Values.global.ioc_group .Values.iocInstance.ioc_group | required "ERROR - You must supply ioc_group or global.ioc_group" -}}
-{{- $opisClaim := default (print $ioc_group "-opi-claim") .Values.iocInstance.opisClaim -}}
-{{- $runtimeClaim := default (print $ioc_group "-runtime-claim") .Values.iocInstance.runtimeClaim -}}
-{{- $autosaveClaim := default (print $ioc_group "-autosave-claim") .Values.iocInstance.autosaveClaim -}}
-{{- $image := .Values.iocInstance.image | required "ERROR - You must supply image." -}}
-
-{{- $enabled := eq .Values.global.enabled false | ternary false true -}}
+{{- $location := default $.Values.global.location .Values.location | required "ERROR - You must supply location or global.location" -}}
+{{- $ioc_group := default $.Values.global.ioc_group .Values.ioc_group | required "ERROR - You must supply ioc_group or global.ioc_group" -}}
+{{- $opisClaim := default (print $ioc_group "-opi-claim") .Values.opisClaim -}}
+{{- $runtimeClaim := default (print $ioc_group "-runtime-claim") .Values.runtimeClaim -}}
+{{- $autosaveClaim := default (print $ioc_group "-autosave-claim") .Values.autosaveClaim -}}
+{{- $image := .Values.image | required "ERROR - You must supply image." -}}
+{{- $enabled := eq $.Values.global.enabled false | ternary false true -}}
 
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $.Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ $.Release.Name }}
     location: {{ $location }}
     ioc_group: {{ $ioc_group }}
     enabled: {{ $enabled | quote }}
@@ -29,25 +34,25 @@ spec:
   podManagementPolicy: Parallel  # force rollout from a failing state
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}
+        app: {{ $.Release.Name }}
         location: {{ $location }}
         ioc_group: {{ $ioc_group }}
         is_ioc: "true"
         # re-deploy in case the configMap has changed - use a random value
         # unless the Commit Hash is supplied (by ArgoCD or helm command line)
-        configHash: {{ .Values.iocInstance.configFolderHash | default "noConfigMap" | quote }}
+        configHash: {{ .Values.configFolderHash | default "noConfigMap" | quote }}
     spec:
-      {{- with .Values.iocInstance.runtimeClassName }}
+      {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . }}
       {{- end }}
-      {{- with .Values.iocInstance.serviceAccountName }}
+      {{- with .Values.serviceAccountName }}
       serviceAccountName: {{ . | quote }}
       {{- end }}
-      hostNetwork: {{ .Values.iocInstance.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
       terminationGracePeriodSeconds: 3 # nice to have quick restarts on IOCs
       volumes:
         - name: runtime-volume
@@ -59,17 +64,17 @@ spec:
         - name: autosave-volume
           persistentVolumeClaim:
             claimName: {{ $autosaveClaim }}
-        {{- with .Values.iocInstance.nfsv2TftpClaim }}
+        {{- with .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
           persistentVolumeClaim:
             claimName: {{ . }}
         {{- end }}
-        {{- if .Values.iocInstance.dataVolume.pvc }}
-        - name: {{ .Release.Name }}-data
+        {{- if .Values.dataVolume.pvc }}
+        - name: {{ $.Release.Name }}-data
           persistentVolumeClaim:
-            claimName: {{ .Release.Name }}-data
+            claimName: {{ $.Release.Name }}-data
         {{- else }}
-        {{- with .Values.iocInstance.dataVolume.hostPath }}
+        {{- with .Values.dataVolume.hostPath }}
         - name: {{ $.Release.Name }}-data
           hostPath:
             path: {{ . }}
@@ -78,33 +83,33 @@ spec:
         {{- end }}
         - name: config-volume
           configMap:
-            name: {{ .Release.Name }}-config
-        {{- with .Values.iocInstance.volumes }}
+            name: {{ $.Release.Name }}-config
+        {{- with .Values.volumes }}
 {{  toYaml . | indent 8}}
         {{- end }}
       containers:
-      - name: {{ .Release.Name }}
-        image: {{ .Values.iocInstance.image }}
+      - name: {{ $.Release.Name }}
+        image: {{ .Values.image }}
         command:
-        {{- if (kindIs "string" .Values.iocInstance.startCommand) }}
-        - {{ .Values.iocInstance.startCommand }}
-        {{- else if (kindIs "slice" .Values.iocInstance.startCommand) }}
-        {{- .Values.iocInstance.startCommand | toYaml | nindent 8 }}
+        {{- if (kindIs "string" .Values.startCommand) }}
+        - {{ .Values.startCommand }}
+        {{- else if (kindIs "slice" .Values.startCommand) }}
+        {{- .Values.startCommand | toYaml | nindent 8 }}
         {{- end }}
         args:
-        {{- if (kindIs "string" .Values.iocInstance.startArgs) }}
-        - {{ .Values.iocInstance.startArgs }}
-        {{- else if (kindIs "slice" .Values.iocInstance.startArgs) }}
-        {{- .Values.iocInstance.startArgs | toYaml | nindent 8 }}
+        {{- if (kindIs "string" .Values.startArgs) }}
+        - {{ .Values.startArgs }}
+        {{- else if (kindIs "slice" .Values.startArgs) }}
+        {{- .Values.startArgs | toYaml | nindent 8 }}
         {{- end }}
         livenessProbe:
           exec:
             command:
-            {{- if (kindIs "string" .Values.iocInstance.liveness) }}
+            {{- if (kindIs "string" .Values.liveness) }}
             - /bin/bash
-            - {{ .Values.iocInstance.liveness }}
-            {{- else if (kindIs "slice" .Values.iocInstance.liveness) }}
-            {{- .Values.iocInstance.liveness | toYaml | nindent 12 }}
+            - {{ .Values.liveness }}
+            {{- else if (kindIs "slice" .Values.liveness) }}
+            {{- .Values.liveness | toYaml | nindent 12 }}
             {{- end }}
           initialDelaySeconds: 120
           periodSeconds: 10
@@ -112,95 +117,95 @@ spec:
           preStop:
             exec:
               command:
-              {{- if (kindIs "string" .Values.iocInstance.stop) }}
+              {{- if (kindIs "string" .Values.stop) }}
               - /bin/bash
-              - {{ .Values.iocInstance.stop }}
-              {{- else if (kindIs "slice" .Values.iocInstance.stop) }}
-              {{- .Values.iocInstance.stop | toYaml | nindent 14 }}
+              - {{ .Values.stop }}
+              {{- else if (kindIs "slice" .Values.stop) }}
+              {{- .Values.stop | toYaml | nindent 14 }}
               {{- end }}
         volumeMounts:
         - name: config-volume
-          mountPath: {{ .Values.iocInstance.iocConfig }}
-        {{- if or (.Values.iocInstance.dataVolume.pvc) (.Values.iocInstance.dataVolume.hostPath)  }}
-        - name: {{ .Release.Name }}-data
-          mountPath: {{ .Values.iocInstance.dataVolume.hostPath }}
-          {{- if .Values.iocInstance.dataVolume.hostPath }}
+          mountPath: {{ .Values.iocConfig }}
+        {{- if or (.Values.dataVolume.pvc) (.Values.dataVolume.hostPath)  }}
+        - name: {{ $.Release.Name }}-data
+          mountPath: {{ .Values.dataVolume.hostPath }}
+          {{- if .Values.dataVolume.hostPath }}
           mountPropagation: HostToContainer
           {{- end}}
         {{- end }}
-        {{- if .Values.iocInstance.nfsv2TftpClaim }}
+        {{- if .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
           mountPath: /nfsv2-tftp
-          subPath: "{{ $ioc_group }}/{{ .Release.Name }}"
+          subPath: "{{ $ioc_group }}/{{ $.Release.Name }}"
         {{- end }}
         - name: runtime-volume
           mountPath: /epics/runtime
-          subPath: "{{ .Release.Name }}"
+          subPath: "{{ $.Release.Name }}"
         - name: opis-volume
           mountPath: /epics/opi
-          subPath: "{{ .Release.Name }}"
+          subPath: "{{ $.Release.Name }}"
         - name: autosave-volume
           mountPath: /autosave
-          subPath: "{{ .Release.Name }}"
-        {{- with .Values.iocInstance.volumeMounts }}
+          subPath: "{{ $.Release.Name }}"
+        {{- with .Values.volumeMounts }}
 {{  toYaml . | indent 8}}
         {{- end }}
         stdin: true
         tty: true
-        {{- with .Values.iocInstance.securityContext }}
+        {{- with .Values.securityContext }}
         securityContext:
 {{  toYaml . | indent 10}}
         {{- end }}
-        {{- with .Values.iocInstance.resources }}
+        {{- with .Values.resources }}
         resources:
 {{  toYaml . | indent 10}}
         {{- end }}
         imagePullPolicy: Always
         env:
         - name: IOCSH_PS1
-          value: "{{ .Release.Name }} > "
+          value: "{{ $.Release.Name }} > "
         - name: IOC_NAME
-          value: {{ .Release.Name }}
+          value: {{ $.Release.Name }}
         - name: IOC_PREFIX
-          value: {{ or .Values.iocInstance.prefix .Release.Name | quote }}
+          value: {{ or .Values.prefix $.Release.Name | quote }}
         - name: IOC_LOCATION
           value: {{ $location | quote }}
         - name: IOC_GROUP
           value: {{ $ioc_group | quote }}
-        {{- with .Values.iocInstance.globalEnv }}
+        {{- with $.Values.globalEnv }}
 {{  toYaml . | indent 8}}
         {{- end }}
-        {{- with .Values.iocInstance.iocEnv }}
+        {{- with .Values.iocEnv }}
 {{  toYaml . | indent 8}}
         {{- end }}
-      {{- with .Values.iocInstance.nodeName }}
+      {{- with .Values.nodeName }}
       nodeName: {{ . }}
       {{- else }}
-      {{- with .Values.iocInstance.affinity }}
+      {{- with .Values.affinity }}
       affinity:
 {{  toYaml . | indent 8}}
       {{- end }}
       {{- end }}
-      {{- with .Values.iocInstance.tolerations }}
+      {{- with .Values.tolerations }}
       tolerations:
 {{  toYaml . | indent 8}}
       {{- end }}
 
-{{ if .Values.iocInstance.dataVolume.pvc }}
+{{ if .Values.dataVolume.pvc }}
 ---
 # This IOC uses a data volume, so we will create a PVC for it
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-data
+  name: {{ $.Release.Name }}-data
   labels:
-    app: {{ .Release.Name }}
+    app: {{ $.Release.Name }}
     location: {{ $location }}
     ioc_group: {{ $ioc_group }}
     is_ioc: "true"
 spec:
-{{- if .Values.iocInstance.dataVolume.spec }}
-{{  toYaml .Values.iocInstance.dataVolume.spec | indent 2 }}
+{{- if .Values.dataVolume.spec }}
+{{  toYaml .Values.dataVolume.spec | indent 2 }}
 {{ else }}
   accessModes:
     - ReadWriteMany
@@ -210,6 +215,6 @@ spec:
 {{- end }}
 {{ else }}
 # This IOC has no data volume, so we will mount the host filesystem
-{{- end }}
-
-{{- end -}}
+{{- end }}  {{/* end if .Values.dataVolume.spec */}}
+{{- end -}} {{/* end with .Values.iocInstance */}}
+{{- end -}} {{/* end define "statefulset" */}}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -1,8 +1,8 @@
 {{- define "ioc-instance.statefulset" -}}
 
 
-{{/* Use with, set to move the iocInstance namespace to the root namespace. */}}
-{{ with .Values.iocInstance }}
+{{/* Use with, set to move the ioc-instance namespace to the root namespace. */}}
+{{ with get .Values "ioc-instance" }}
 {{- $_ := set . "Values" . -}}
 
 {{- /*
@@ -44,7 +44,7 @@ spec:
         is_ioc: "true"
         # re-deploy in case the configMap has changed - use a random value
         # unless the Commit Hash is supplied (by ArgoCD or helm command line)
-        configHash: {{ .Values.configFolderHash | default "noConfigMap" | quote }}
+        configHash: {{ $.Values.configFolderHash | default "noConfigMap" | quote }}
     spec:
       {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . }}
@@ -216,5 +216,5 @@ spec:
 {{ else }}
 # This IOC has no data volume, so we will mount the host filesystem
 {{- end }}  {{/* end if .Values.dataVolume.spec */}}
-{{- end -}} {{/* end with .Values.iocInstance */}}
+{{- end -}} {{/* end with .Values.ioc-instance */}}
 {{- end -}} {{/* end define "statefulset" */}}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -128,7 +128,7 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: {{ .iocConfig }}
-        {{- if or (.Values.dataVolume.pvc) (.Values.dataVolume.hostPath)  }}
+        {{- if or (.dataVolume.pvc) (.dataVolume.hostPath) }}
         - name: {{ $.Release.Name }}-data
           mountPath: {{ .dataVolume.hostPath }}
           {{- if .dataVolume.hostPath }}

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -1,9 +1,9 @@
 exports:
   defaults:
-    iocInstance:
-      # yaml-language-server: $schema=../../Schemas/iocInstance.schema.json/#/$defs/base
+    ioc-instance:
+      # yaml-language-server: $schema=../../Schemas/ioc-instance.schema.json/#/$defs/base
 
-      ########### Values defaults for iocInstance Helm Chart ########################
+      ########### Values defaults for ioc-instance Helm Chart ########################
 
       ################################################################################
       # Values that all IOCs MUST set
@@ -15,7 +15,7 @@ exports:
 
       # The location where the IOCs will run.
       # This creates a label 'location'
-      # NOTE: this value can also be set in global: instead of iocInstance:
+      # NOTE: this value can also be set in global: instead of ioc-instance:
       location: ""
 
       ################################################################################


### PR DESCRIPTION
I had an epiphany in the shower.

This restores the name ioc-instance as the values namespace for the ioc-instance chart. Which makes the breaking change into a non-breaking change because now the library chart requires precisely the same values file layout as the original application chart.

The key is this. Variables called .Values.ioc-instance are illegal. But dictionaries with a key 'ioc-instance' are not. The following yaml extracts the key and sets its content as the root namespace. This also makes the changes to the rest of the chart less invasive because you no longer need to say .Values.iocInstance.xxx for every value you access.
```yaml
{{ with get .Values "ioc-instance" }}
{{- $_ := set . "Values" . -}}
```

@GDYendell I originally had hoped to remove kebab-case from our files but looking in more detail, K8S uses kebab alot for values, and is inconsistent anyway. I quite like the name ioc-instance and am happy to make this into a non-breaking change.