### PR TITLE
Use ioc-instance.env and global.env to specifiy environment variables

### DIFF
--- a/Charts/epics-pvcs/templates/pod.yaml
+++ b/Charts/epics-pvcs/templates/pod.yaml
@@ -95,8 +95,10 @@ spec:
             value: {{ $location | quote }}
           - name: IOC_DOMAIN
             value: {{ $domain | quote }}
-          {{- with .globalEnv }}
-            {{- toYaml . | nindent 10 }}
+          # globals: {{ .Values.global | quote }}
+          {{- range .Values.global.env }}
+          - name: {{ .name }}
+            value: {{ .value }}
           {{- end }}
       {{- with .Values.nodeName }}
       nodeName: {{ . }}

--- a/Charts/epics-pvcs/values.yaml
+++ b/Charts/epics-pvcs/values.yaml
@@ -1,9 +1,17 @@
-# Short name for this collection of services
+# @schema additionalProperties: true
+global:
+  # @schema  $ref:$k8s/container.json#/properties/env
+  env: []
+
+# @schema description: Short name for this collection of services
 domain:
-# location where these IOCs and services will run
+# @schema description: location where these IOCs and services will run
 location:
-# sizes of the auto provisioned PVs
+# @schema description: sizes of the auto provisioned PVs
 opiSize: 1Gi
 runtimeSize: 1Gi
 autosaveSize: 1Gi
 binariesSize: 1Gi
+
+# @schema  $ref:$k8s/container.json#/properties/env
+env: []

--- a/Charts/ioc-instance/ioc-instance.schema.json
+++ b/Charts/ioc-instance/ioc-instance.schema.json
@@ -32,12 +32,14 @@
             }
         },
         "global": {
-            "description": "Global values shared between all subcharts",
-            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key.",
-            "type": [
-                "object",
-                "null"
-            ]
+            "type": "object",
+            "properties": {
+                "env": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/env",
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true
         },
         "ioc-instance": {
             "type": "object",
@@ -96,19 +98,20 @@
                     "description": "the domain IOCs run in, e.g. p47, b01-1, rf, va",
                     "type": "string"
                 },
+                "env": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/env",
+                    "type": "array"
+                },
                 "extraContainers": {
                     "type": "array"
                 },
-                "globalEnv": {
-                    "description": "Environment variables to add to the pod",
-                    "type": "array"
-                },
                 "hostNetwork": {
-                    "description": "enable host networking for the pod",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/hostNetwork",
                     "type": "boolean"
                 },
                 "image": {
                     "description": "containerimage URI for the Generic IOC. Mandatory override.",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/image",
                     "type": "string"
                 },
                 "imagePullPolicy": {
@@ -118,9 +121,6 @@
                 "iocConfig": {
                     "description": "config folder mount point inside generic IOC container",
                     "type": "string"
-                },
-                "iocEnv": {
-                    "type": "array"
                 },
                 "iocFolder": {
                     "description": "root folder for ioc source/binaries inside generic IOC container",
@@ -181,7 +181,7 @@
                     "type": "string"
                 },
                 "nodeName": {
-                    "description": "nodeName is used to run on a specific node. Overrides affinity",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/nodeName",
                     "type": "string"
                 },
                 "opisClaim": {
@@ -189,12 +189,17 @@
                     "type": "string"
                 },
                 "podAnnotations": {
-                    "description": "Add annotations to the pod",
+                    "description": "list of additional annotations to apply o the pod",
                     "type": "object",
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
                     "additionalProperties": false
                 },
                 "podLabels": {
-                    "description": "Add labels to the pod",
+                    "description": "list of additional labels to apply o the pod",
                     "type": "object",
                     "additionalProperties": false
                 },
@@ -244,6 +249,7 @@
                 },
                 "runtimeClassName": {
                     "description": "at DLS set to 'usb-compat' for mounting in USB devices",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/runtimeClassName",
                     "type": "string"
                 },
                 "securityContext": {
@@ -258,7 +264,7 @@
                     "additionalProperties": false
                 },
                 "serviceAccountName": {
-                    "description": "specify the service account",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/serviceAccountName",
                     "type": "string"
                 },
                 "tolerations": {

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -196,11 +196,15 @@ spec:
           value: /tmp
         - name: TERM
           value: xterm-256color
-        {{- with .globalEnv }}
-          {{- toYaml . | nindent 8 }}
+
+        {{- /* Add in the global and instance additional environment vars */}}
+        {{- range $.Values.global.env }}
+        - name: {{ .name }}
+          value: {{ .value }}
         {{- end }}
-        {{- with .iocEnv }}
-          {{- toYaml . | nindent 8 }}
+        {{- range .env }}
+        - name: {{ .name }}
+          value: {{ .value }}
         {{- end }}
 
       {{- /* Additional ad hoc containers ***********************************/}}
@@ -215,12 +219,17 @@ spec:
             value: /tmp
           - name: TERM
             value: xterm-256color
-          {{- with $root.globalEnv }}
-            {{- toYaml . | nindent 10 }}
+
+          {{- /* Add in additional environment vars */}}
+          {{- range $.Values.global.env }}
+          - name: {{ .name }}
+            value: {{ .value }}
           {{- end }}
-          {{- with $root.iocEnv }}
-            {{- toYaml . | nindent 10 }}
+          {{- range $root.env }}
+          - name: {{ .name }}
+            value: {{ .value }}
           {{- end }}
+
         {{- with $root.securityContext }}
         securityContext:
           {{- toYaml . | nindent 12 }}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -198,11 +198,11 @@ spec:
           value: xterm-256color
 
         {{- /* Add in the global and instance additional environment vars */}}
-        {{- range $.Values.global.env }}
+        {{- range .env }}
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }}
-        {{- range .env }}
+        {{- range $.Values.global.env }}
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }}
@@ -221,11 +221,11 @@ spec:
             value: xterm-256color
 
           {{- /* Add in additional environment vars */}}
-          {{- range $.Values.global.env }}
+          {{- range $root.env }}
           - name: {{ .name }}
             value: {{ .value }}
           {{- end }}
-          {{- range $root.env }}
+          {{- range $.Values.global.env }}
           - name: {{ .name }}
             value: {{ .value }}
           {{- end }}

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -8,12 +8,18 @@
 #   https://github.com/yannh/kubernetes-json-schema/tree/master/v1.33.1
 #   with version from Charts/ioc-instance/.schema.config.yaml (k8sSchemaVersion)
 
+# @schema additionalProperties: true
+global:
+  # @schema  $ref:$k8s/container.json#/properties/env
+  env: []
+
 ioc-instance:
   ################################################################################
   # Values that all IOCs MUST set
   ################################################################################
 
   # @schema description: containerimage URI for the Generic IOC. Mandatory override.
+  # @schema $ref:$k8s/container.json#/properties/image
   image: ""
 
   # @schema $ref: $k8s/container.json#/properties/imagePullPolicy
@@ -31,12 +37,12 @@ ioc-instance:
   domain: ""
 
   # @schema description: at DLS set to 'usb-compat' for mounting in USB devices
+  # @schema  $ref:$k8s/podspec.json#/properties/runtimeClassName
   runtimeClassName: ""
 
-  # @schema description: specify the service account
+  # @schema  $ref:$k8s/podspec.json#/properties/serviceAccountName
   serviceAccountName: ""
-
-  # @schema description: enable host networking for the pod
+  # @schema  $ref:$k8s/podspec.json#/properties/hostNetwork
   hostNetwork: true
 
   # @schema description: root folder for ioc source/binaries inside generic IOC container
@@ -71,13 +77,8 @@ ioc-instance:
     initialDelaySeconds: 120
     periodSeconds: 10
 
-  # @schema description: Environment variables to add to the pod
-  globalEnv: []
-  # - name:
-  #   value:
-  iocEnv: []
-  # - name:
-  #   value:
+  # @schema  $ref:$k8s/container.json#/properties/env
+  env: []
 
   # @schema description: specify the security context. At DLS the IOCs should use iXXdetector user/group IDs
   # @schema  $ref:$k8s/container.json#/properties/securityContext
@@ -104,7 +105,7 @@ ioc-instance:
   # @schema $ref: $k8s/container.json#/properties/volumeMounts
   volumeMounts: []
 
-  # @schema description: nodeName is used to run on a specific node. Overrides affinity
+  # @schema $ref: $k8s/podspec.json#/properties/nodeName
   nodeName: ""
 
   # @schema $ref: $k8s/affinity.json
@@ -141,13 +142,14 @@ ioc-instance:
   ##############################################################################
 
   # Add additional containers specified by image and command
-  # see extra.values.yaml for the schema of this list of objects
+  # see example.values.yaml for the schema of this list of objects
   extraContainers: []
 
-  # @schema description: Add annotations to the pod
-  podAnnotations: {}
+  # @schema description: list of additional annotations to apply o the pod
+  podAnnotations:
+    test: hello
 
-  # @schema description: Add labels to the pod
+  # @schema description: list of additional labels to apply o the pod
   podLabels: {}
 
   # @schema $ref: $k8s/podspec.json#/properties/securityContext


### PR DESCRIPTION
@GDYendell this came out OK in the end. 

When I add env and global.env to the list of environment variables, any name clashes are dropped. So its a first in wins.

I don't know where this happens as helm itself just renders both when I do it locally.