### PR TITLE
Simplify config for livenessProbe and preStop

### DIFF
--- a/Charts/ioc-instance/ioc-instance.schema.json
+++ b/Charts/ioc-instance/ioc-instance.schema.json
@@ -129,51 +129,15 @@
                 "lifecycle": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/lifecycle",
                     "type": "object",
-                    "properties": {
-                        "preStop": {
-                            "type": "object",
-                            "properties": {
-                                "exec": {
-                                    "type": "object",
-                                    "properties": {
-                                        "command": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
                     "additionalProperties": false
+                },
+                "livenessExecutable": {
+                    "description": "simple livenessprobe config",
+                    "type": "string"
                 },
                 "livenessProbe": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/readinessProbe",
                     "type": "object",
-                    "properties": {
-                        "exec": {
-                            "type": "object",
-                            "properties": {
-                                "command": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        }
-                    },
                     "additionalProperties": false
                 },
                 "location": {
@@ -207,6 +171,10 @@
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/securityContext",
                     "type": "object",
                     "additionalProperties": false
+                },
+                "preStopExecutable": {
+                    "description": "simple lifecycle config",
+                    "type": "string"
                 },
                 "pvaServerPort": {
                     "description": "server port for pv access. The UDP broadcast port will be one greater.",

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -135,15 +135,43 @@ spec:
         {{- with .args }}
         args:
           {{- . | toYaml | nindent 10 }}
-        {{- end }}
+        {{- end -}}
+
+        {{/* supply a complete liveness probe object */}}
         {{- with .livenessProbe }}
         livenessProbe:
           {{- . | toYaml | nindent 10 }}
+        {{- else }}
+        {{/* or just the executable for default livenessProbe behaviour */}}
+        {{- with .livenessExecutable -}}
+        livenessProbe:
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - .
+          initialDelaySeconds: 120
+          periodSeconds: 30
         {{- end }}
-        {{ with .lifecycle }}
+        {{- end -}}
+
+        {{/* supply a complete lifecycle object */}}
+        {{- with .lifecycle }}
         lifecycle:
           {{- . | toYaml | nindent 10 }}
+        {{- else }}
+        {{/* or just the stop executable for default lifecycle behaviour */}}
+        {{- with .preStopExecutable }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - .
         {{- end }}
+        {{- end }}
+
         volumeMounts:
         - name: config-volume
           mountPath: {{ .iocConfig }}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -149,7 +149,7 @@ spec:
             command:
               - /bin/bash
               - -c
-              - .
+              - {{ . }}
           initialDelaySeconds: 120
           periodSeconds: 30
         {{- end }}
@@ -168,7 +168,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - .
+                - {{ . }}
         {{- end }}
         {{- end }}
 

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -61,21 +61,16 @@ ioc-instance:
     - /epics/ioc/start.sh
 
   # @schema $ref: $k8s/container.json#/properties/lifecycle
-  lifecycle:
-    preStop:
-      exec:
-        command:
-          - /bin/bash
-          - /epics/ioc/stop.sh
+  lifecycle: {}
+
+  # @schema description: simple lifecycle config
+  preStopExecutable: /epics/ioc/stop.sh
 
   # @schema $ref: $k8s/container.json#/properties/readinessProbe
-  livenessProbe:
-    exec:
-      command:
-        - /bin/bash
-        - /epics/ioc/liveness.sh
-    initialDelaySeconds: 120
-    periodSeconds: 10
+  livenessProbe: {}
+
+  # @schema description: simple livenessprobe config
+  livenessExecutable: /epics/ioc/liveness.sh
 
   # @schema  $ref:$k8s/container.json#/properties/env
   env: []


### PR DESCRIPTION
till allow a full object to be supplied but also support default configuration that just takes the name of the preStop or livenessProbe executable.

This make it much easier to specify that fastcs IOCs don't yet have a livenessProbe or preStop.