### PR TITLE
feat: add startup and readiness probes to ioc-instance chart

### DIFF
--- a/Charts/ioc-instance/ioc-instance.schema.json
+++ b/Charts/ioc-instance/ioc-instance.schema.json
@@ -183,7 +183,7 @@
                     "type": "string"
                 },
                 "livenessProbe": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/readinessProbe",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/livenessProbe",
                     "type": "object",
                     "additionalProperties": false
                 },
@@ -225,6 +225,15 @@
                 "pvaServerPort": {
                     "description": "server port for pv access. The UDP broadcast port will be one greater.",
                     "type": "integer"
+                },
+                "readinessExecutable": {
+                    "description": "simple readinessprobe config",
+                    "type": "string"
+                },
+                "readinessProbe": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/readinessProbe",
+                    "type": "object",
+                    "additionalProperties": false
                 },
                 "rebootEveryCommit": {
                     "description": "when true the ioc will reboot on every commit",
@@ -279,6 +288,15 @@
                 "serviceAccountName": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/serviceAccountName",
                     "type": "string"
+                },
+                "startupExecutable": {
+                    "description": "simple startupprobe config",
+                    "type": "string"
+                },
+                "startupProbe": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/startupProbe",
+                    "type": "object",
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/tolerations",

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -147,6 +147,40 @@ spec:
         args:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
+        {{/* supply a complete startup probe object */}}
+        {{- with .startupProbe }}
+        startupProbe:
+          {{- . | toYaml | nindent 10 }}
+        {{- else }}
+        {{/* or just the executable for default startupProbe behaviour */}}
+        {{- with .startupExecutable }}
+        startupProbe:
+          exec:
+            command:
+              - /bin/bash
+              - {{ . }}
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          failureThreshold: 2600000 # ~ a month if period kept at 1s
+          timeoutSeconds: 1300000 # ~ half a month
+        {{- end }}
+        {{- end }}
+        {{/* supply a complete readiness probe object */}}
+        {{- with .readinessProbe }}
+        readinessProbe:
+          {{- . | toYaml | nindent 10 }}
+        {{- else }}
+        {{/* or just the executable for default readinessProbe behaviour */}}
+        {{- with .readinessExecutable }}
+        readinessProbe:
+          exec:
+            command:
+              - /bin/bash
+              - {{ . }}
+          initialDelaySeconds: 20
+          periodSeconds: 30
+        {{- end }}
+        {{- end }}
         {{/* supply a complete liveness probe object */}}
         {{- with .livenessProbe }}
         livenessProbe:
@@ -240,7 +274,6 @@ spec:
           value: /tmp
         - name: TERM
           value: xterm-256color
-
         {{- /* Add in the global and instance additional environment vars */}}
         {{- range $root.env }}
         - name: {{ .name }}

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -69,7 +69,20 @@ ioc-instance:
   # @schema description: simple lifecycle config
   preStopExecutable: /epics/ioc/stop.sh
 
+  # @schema $ref: $k8s/container.json#/properties/startupProbe
+  startupProbe: {}
+
+  # @schema description: simple startupprobe config
+  startupExecutable: /epics/ioc/startup.sh
+
   # @schema $ref: $k8s/container.json#/properties/readinessProbe
+  readinessProbe: {}
+
+  # @schema description: simple readinessprobe config
+  # Until a generic readiness script is available, disable the readiness probe by default to avoid confusion.
+  readinessExecutable: ""
+
+  # @schema $ref: $k8s/container.json#/properties/livenessProbe
   livenessProbe: {}
 
   # @schema description: simple livenessprobe config


### PR DESCRIPTION
Add configurable startup and readiness probes alongside the existing liveness probe. Both support either a full probe object or a simple executable path shorthand (startupExecutable / readinessExecutable).

The startup probe defaults to a very long failure threshold and timeout (~1 month / ~half a month) to accommodate slow-starting IOCs or IOCs requiring connection(s) to specific hardware resources. The readiness probe is disabled by default (readinessExecutable: "") until a generic readiness script is available.