### PR TITLE
Add additional PVCs feature

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:github.com)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,11 @@ repos:
         args:
           - --config
           - Charts/argocd-apps/.schema.config.yaml
+
+  - repo: https://github.com/losisin/helm-values-schema-json
+    rev: v2.3.1
+    hooks:
+      - id: helm-schema
+        args:
+          - --config
+          - Charts/epics-pvcs/.schema.config.yaml

--- a/Charts/epics-pvcs/.schema.config.yaml
+++ b/Charts/epics-pvcs/.schema.config.yaml
@@ -1,0 +1,30 @@
+# .schema.yaml
+
+# Define input, output and source for $refs relative to repository root for pre-commit
+values:
+  - Charts/epics-pvcs/values.yaml
+  - Charts/epics-pvcs/example.values.yaml
+
+# Do not call this values.schema.json because this is a library chart.
+# When importing default values into the parent the schema check that would fail
+# if it sees values.schema.json and tries to use it (I think because the check assumes
+# that the contents of ioc-instance is going into the root?)
+output: Charts/epics-pvcs/epics-pvcs.schema.json
+
+# bundle up references (don't do this as K8S refs are 500kb+)
+bundleRoot: Charts
+bundle: false
+
+# Include comments for the helm-docs plugin into the schema, to allow e.g. documentation in VSCode
+useHelmDocs: false
+
+# Allow additional properties for eg. initResources, different types of volumes/volumeMounts
+noAdditionalProperties: true
+
+schemaRoot:
+  title: epics-pvcs Helm chart
+  description: Helm chart for deploying EPICS PVCs
+  # No additional properties in schema root for tighter protection:
+  additionalProperties: false
+
+k8sSchemaVersion: v1.33.3

--- a/Charts/epics-pvcs/epics-pvcs.schema.json
+++ b/Charts/epics-pvcs/epics-pvcs.schema.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "epics-pvcs Helm chart",
+    "description": "Helm chart for deploying EPICS PVCs",
+    "type": "object",
+    "properties": {
+        "additionalPvcs": {
+            "description": "additional PVCs to create for this domain and location",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "size"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "autosaveSize": {
+            "type": "string"
+        },
+        "binariesSize": {
+            "type": "string"
+        },
+        "domain": {
+            "description": "Short name for this collection of services",
+            "type": "null"
+        },
+        "env": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/env",
+            "type": "array"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "env": {
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/env",
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true
+        },
+        "location": {
+            "description": "location where these IOCs and services will run",
+            "type": "null"
+        },
+        "opiSize": {
+            "description": "sizes of the auto provisioned PVs",
+            "type": "string"
+        },
+        "runtimeSize": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": false
+}

--- a/Charts/epics-pvcs/example.values.yaml
+++ b/Charts/epics-pvcs/example.values.yaml
@@ -1,0 +1,7 @@
+# examples of objects in values.yaml that default to empty and have no K8S schema
+# used for generating schema for these objects
+# see .schema.config.yaml
+
+additionalPvcs:
+  - name: my-pvc # @schema required
+    size: 1Gi # @schema required

--- a/Charts/epics-pvcs/templates/deploy.yaml
+++ b/Charts/epics-pvcs/templates/deploy.yaml
@@ -79,7 +79,7 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ .name }}
+  name: {{ .name }}-claim
   labels:
     app: {{ $.Release.Name }}
     location: {{ $location }}

--- a/Charts/epics-pvcs/templates/deploy.yaml
+++ b/Charts/epics-pvcs/templates/deploy.yaml
@@ -73,3 +73,21 @@ spec:
   resources:
     requests:
       storage: {{ .Values.binariesSize }}
+---
+# Any additional PVCs defined by the user
+{{- range .Values.additionalPvcs }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ $.Release.Name }}
+    location: {{ $location }}
+    domain: {{ $domain }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .size }}
+{{- end }}

--- a/Charts/epics-pvcs/templates/deploy.yaml
+++ b/Charts/epics-pvcs/templates/deploy.yaml
@@ -79,7 +79,7 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ .name }}-claim
+  name: {{ printf "%s-%s-claim" $domain .name }}
   labels:
     app: {{ $.Release.Name }}
     location: {{ $location }}

--- a/Charts/epics-pvcs/templates/deploy.yaml
+++ b/Charts/epics-pvcs/templates/deploy.yaml
@@ -80,6 +80,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ printf "%s-%s-claim" $domain .name }}
+  annotations:
+    # only delete the additional PVCs manually, else recovered automatically
+    helm.sh/resource-policy: keep
+    argocd.argoproj.io/sync-options: Delete=false
   labels:
     app: {{ $.Release.Name }}
     location: {{ $location }}

--- a/Charts/epics-pvcs/templates/pod.yaml
+++ b/Charts/epics-pvcs/templates/pod.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: {{ $autosaveClaim }}
         {{- range .Values.additionalPvcs }}
         - name: {{ .name }}-volume
-            persistentVolumeClaim:
+          persistentVolumeClaim:
             claimName: {{ printf "%s-%s-claim" $domain .name }}
         {{- end }}
         {{- with .Values.nfsv2TftpClaim }}

--- a/Charts/epics-pvcs/templates/pod.yaml
+++ b/Charts/epics-pvcs/templates/pod.yaml
@@ -48,6 +48,11 @@ spec:
         - name: autosave-volume
           persistentVolumeClaim:
             claimName: {{ $autosaveClaim }}
+        {{- range .Values.additionalPvcs }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .name }}
+        {{- end }}
         {{- with .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
           persistentVolumeClaim:
@@ -74,6 +79,10 @@ spec:
           mountPath: /mounts/opis
         - name: autosave-volume
           mountPath: /mounts/autosave
+        {{- range .Values.additionalPvcs }}
+        - name: {{ .name }}
+          mountPath: /mounts/{{ .name }}
+        {{- end }}
         {{- with .Values.volumeMounts }}
           {{  toYaml . | nindent 10 }}
         {{- end }}

--- a/Charts/epics-pvcs/templates/pod.yaml
+++ b/Charts/epics-pvcs/templates/pod.yaml
@@ -50,8 +50,8 @@ spec:
             claimName: {{ $autosaveClaim }}
         {{- range .Values.additionalPvcs }}
         - name: {{ .name }}-volume
-          persistentVolumeClaim:
-            claimName: {{ .name }}-claim
+            persistentVolumeClaim:
+            claimName: {{ printf "%s-%s-claim" $domain .name }}
         {{- end }}
         {{- with .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume

--- a/Charts/epics-pvcs/templates/pod.yaml
+++ b/Charts/epics-pvcs/templates/pod.yaml
@@ -49,9 +49,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ $autosaveClaim }}
         {{- range .Values.additionalPvcs }}
-        - name: {{ .name }}
+        - name: {{ .name }}-volume
           persistentVolumeClaim:
-            claimName: {{ .name }}
+            claimName: {{ .name }}-claim
         {{- end }}
         {{- with .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
@@ -80,7 +80,7 @@ spec:
         - name: autosave-volume
           mountPath: /mounts/autosave
         {{- range .Values.additionalPvcs }}
-        - name: {{ .name }}
+        - name: {{ .name }}-volume
           mountPath: /mounts/{{ .name }}
         {{- end }}
         {{- with .Values.volumeMounts }}

--- a/Charts/epics-pvcs/values.yaml
+++ b/Charts/epics-pvcs/values.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=epics-pvcs.schema.json
+
 # @schema additionalProperties: true
 global:
   # @schema  $ref:$k8s/container.json#/properties/env
@@ -15,3 +17,6 @@ binariesSize: 1Gi
 
 # @schema  $ref:$k8s/container.json#/properties/env
 env: []
+
+# @schema description: additional PVCs to create for this domain and location
+additionalPvcs: []


### PR DESCRIPTION
This pull request adds support for specifying and managing additional PersistentVolumeClaims (PVCs) in the `epics-pvcs` Helm chart. It introduces schema validation for these new values, updates templating to provision and mount user-defined PVCs, and integrates a pre-commit hook to ensure schema compliance.

The most important changes are grouped below:

**Helm chart feature: additional PVCs**
* Added support for user-defined additional PVCs via a new `additionalPvcs` array in `values.yaml`, including example usage and schema documentation.
* Updated `deploy.yaml` template to create PVC resources for each entry in `additionalPvcs`.
* Updated `pod.yaml` template to mount each additional PVC as a volume and at a corresponding mount path.

**Schema validation and tooling**
* Added a JSON schema for the `epics-pvcs` chart, describing the structure and requirements for `additionalPvcs` and other values.
* Added a schema config file and integrated the `helm-values-schema-json` pre-commit hook to enforce schema compliance on changes.

**Other**
* Enabled GitHub domain fetch permissions for Claude in `.claude/settings.local.json`.