### PR TITLE
Allow deployment settings to override destination fields for argocd-apps

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -17,8 +17,8 @@ metadata:
 spec:
   project: {{ default $.Release.Namespace $.Values.project }}
   destination:
-    namespace: {{ $.Values.destination.namespace }}
-    name: {{ $.Values.destination.name }}
+    namespace: {{ default $.Values.destination.namespace $settings.destination.namespace }}
+    name: {{ default $.Values.destination.name $settings.destination.name }}
   source:
     repoURL: {{ default $.Values.source.repoURL $settings.repoURL }}
     path: services/{{ $service }}

--- a/Charts/argocd-apps/values.schema.json
+++ b/Charts/argocd-apps/values.schema.json
@@ -45,6 +45,20 @@
                         "default": true,
                         "type": "boolean"
                     },
+                    "destination": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "name": {
+                            "default": "",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "default": "",
+                            "type": "string"
+                        }
+                    },
                     "labels": {
                         "default": {},
                         "type": "object",

--- a/Charts/argocd-apps/values.schema.json
+++ b/Charts/argocd-apps/values.schema.json
@@ -41,23 +41,26 @@
                     "null"
                 ],
                 "properties": {
-                    "enabled": {
-                        "default": true,
-                        "type": "boolean"
-                    },
                     "destination": {
                         "type": [
                             "object",
                             "null"
                         ],
-                        "name": {
-                            "default": "",
-                            "type": "string"
+                        "properties": {
+                            "name": {
+                                "default": "",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "default": "",
+                                "type": "string"
+                            }
                         },
-                        "namespace": {
-                            "default": "",
-                            "type": "string"
-                        }
+                        "additionalProperties": false
+                    },
+                    "enabled": {
+                        "default": true,
+                        "type": "boolean"
                     },
                     "labels": {
                         "default": {},

--- a/Charts/argocd-apps/values.yaml
+++ b/Charts/argocd-apps/values.yaml
@@ -26,6 +26,9 @@ source:
 services:
   # Each item is of the form:
   #   service: service name as it appears in K8S (statefulset/deployment name)
+  #     destination: optional override for destination parameters above
+  #       name: optional override for the deployment cluster above
+  #       namespace: optional override for namespace above
   #     targetRevision: optional override for targetRevision above
   #     repoURL: optional override for git repo to source the helm chart from
   #            the path is always services/<service> within that repo
@@ -34,6 +37,18 @@ services:
 
   # @schema type: [object, null]
   example1:
+
+    # @schema type: [object, null]
+    destination:
+
+      # @schema type: string
+      # @schema default: ""
+      name: ""
+
+      # @schema type: string
+      # @schema default: ""
+      namespace: ""
+
     # @schema type: object
     # @schema additionalProperties: {"type":"string","maxLength":63,"description":"Custom labels applied to the resource.","pattern":"^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$|^[a-zA-Z0-9]$"}
     # @schema default: {}


### PR DESCRIPTION
Gives the user control over what cluster and namespace they deploy each service's app to.

In the example below, we have a staging cluster that would like to be deployed in a separate cluster to the production app. The change allows us to keep the global cluster setting for the production app, but modify the development app to deploy to pollux.

e.g.
```
services:
  gitlab-runners-prod:

  gitlab-runners-dev:
    destination:
      name: pollux
    valuesFiles:
      - values.yaml
      - values-dev.yaml
```

I suspect it will be unlikely you would want to deploy apps into multiple namespaces at once, but have included the option to support greater flexibility in the override parameters. Let me know if you would prefer to leave that option out of this PR.