### PR TITLE
Allow deployment settings to override values files & objects for argocd-apps

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -42,7 +42,7 @@ spec:
           labels:
         {{- toYaml . | nindent 12 }}
         {{- end}}
-      {{ - with $settings.valuesObject }}
+      {{- with $settings.valuesObject }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $settings.valuesFiles }}

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -41,7 +41,7 @@ spec:
           labels:
       {{- toYaml . | nindent 12 }}
       {{- end }}
-      {{- with $settings.values }}
+      {{- with $settings.valuesFiles }}
       valueFiles:
       {{- toYaml . | nindent 8 }}
       {{- else }}

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -35,11 +35,15 @@ spec:
           value: $ARGOCD_APP_SOURCE_REPO_URL
         - name: global.sourcePath
           value: $ARGOCD_APP_SOURCE_PATH
-      {{- with $settings.labels }}
+      {{- if or $settings.labels $settings.valuesObject }}
       valuesObject:
+        {{- with $settings.labels }}
         global:
           labels:
-      {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 12 }}
+        {{- end}}
+      {{ - with $settings.valuesObject }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $settings.valuesFiles }}
       valueFiles:

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -41,9 +41,14 @@ spec:
           labels:
       {{- toYaml . | nindent 12 }}
       {{- end }}
+      {{- with $settings.values }}
+      valueFiles:
+      {{- toYaml . | nindent 8 }}
+      {{- else }}
       valueFiles:
         - ../values.yaml
         - values.yaml
+      {{- end }}
   syncPolicy:
     automated:
 

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -45,6 +45,7 @@ spec:
       {{- with $settings.valuesObject }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- end }}
       {{- with $settings.valuesFiles }}
       valueFiles:
       {{- toYaml . | nindent 8 }}

--- a/Charts/argocd-apps/values.schema.json
+++ b/Charts/argocd-apps/values.schema.json
@@ -67,7 +67,12 @@
                         "default": "",
                         "type": "string"
                     },
-                    "values": {
+                    "valuesFiles": {
+                        "default": [],
+                        "type": "array"
+                    },
+                    "valuesObject": {
+                        "default": {},
                         "type": "object",
                         "additionalProperties": false
                     }

--- a/Charts/argocd-apps/values.yaml
+++ b/Charts/argocd-apps/values.yaml
@@ -29,6 +29,12 @@ services:
   #     targetRevision: optional override for targetRevision above
   #     repoURL: optional override for git repo to source the helm chart from
   #            the path is always services/<service> within that repo
+  #     valuesObject: An object that is passed as values to the helm chart.
+  #                 This is merged with the default values.yaml in the repo,
+  #                 with valuesObject taking precedence.
+  #     valuesFiles: A list of paths to values.yaml files that are passed to
+  #                 the helm chart. Subsequent files in the list override
+  #                 the previous ones.
   #     removed: set to true to remove the service from the cluster
   #     enabled: set to false to stop a service
 
@@ -56,4 +62,9 @@ services:
     enabled: true
 
     # @schema type: object
-    values: {}
+    # @schema default: {}
+    valuesObject: {}
+
+    # @schema type: array
+    # @schema default: []
+    valuesFiles: []


### PR DESCRIPTION
Gives the user control over what values files are used in the given app. This is useful for overriding a small amount of properties that a base values.yaml sets for different purposes (i.e. production and staging deployments).

This change was prepared in the schema but never implemented in the template file (See https://github.com/epics-containers/ec-helm-charts/pull/92). This MR is the actual implementation of this feature.

Resolves: https://github.com/epics-containers/ec-helm-charts/issues/94