### PR TITLE
Always define service.destination block to avoid nil parsing

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -16,9 +16,10 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ default $.Release.Namespace $.Values.project }}
+  {{- $settingsDestination := default dict $settings.destination -}}
   destination:
-    namespace: {{ default $.Values.destination.namespace $settings.destination.namespace }}
-    name: {{ default $.Values.destination.name $settings.destination.name }}
+    namespace: {{ default $.Values.destination.namespace $settingsDestination.namespace }}
+    name: {{ default $.Values.destination.name $settingsDestination.name }}
   source:
     repoURL: {{ default $.Values.source.repoURL $settings.repoURL }}
     path: services/{{ $service }}

--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -16,7 +16,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ default $.Release.Namespace $.Values.project }}
-  {{- $settingsDestination := default dict $settings.destination -}}
+  {{- $settingsDestination := default dict $settings.destination }}
   destination:
     namespace: {{ default $.Values.destination.namespace $settingsDestination.namespace }}
     name: {{ default $.Values.destination.name $settingsDestination.name }}


### PR DESCRIPTION
When parsing YAML, the YAML parser only creates a dict with the fields you have provided. If you do not provide anything, then nothing is defined. If nothing is defined, then when you try to access it in code you get a nil pointer exception.

With the settings object, it was correctly assigned to a default dict so that if no settings were defined, then an empty settings dict is still created: `{{ $settings := default dict $settings -}}`
`$settings` could then be used throughout the _apps.tpl file to make comparisons against.

What I did not account for is that `$settings.destination` is a nested dict and so ALSO needs to be assigned an empty dict if not defined. This PR applies this fix.