### PR TITLE
Add service helm chart override option

### DIFF
--- a/Charts/argocd-apps/templates/_apps.tpl
+++ b/Charts/argocd-apps/templates/_apps.tpl
@@ -21,7 +21,7 @@ spec:
     name: {{ default $.Values.destination.name $settings.destination.name }}
   source:
     repoURL: {{ default $.Values.source.repoURL $settings.repoURL }}
-    path: services/{{ $service }}
+    path: services/{{ default $service $settings.serviceChart }}
     targetRevision: {{ default $.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/Charts/argocd-apps/values.schema.json
+++ b/Charts/argocd-apps/values.schema.json
@@ -80,6 +80,10 @@
                         "default": "",
                         "type": "string"
                     },
+                    "serviceChart": {
+                        "default": "",
+                        "type": "string"
+                    },
                     "targetRevision": {
                         "default": "",
                         "type": "string"

--- a/Charts/argocd-apps/values.yaml
+++ b/Charts/argocd-apps/values.yaml
@@ -25,21 +25,23 @@ source:
 # @schema mergeProperties: true
 services:
   # Each item is of the form:
-  #   service: service name as it appears in K8S (statefulset/deployment name)
-  #     destination: optional override for destination parameters above
-  #       name: optional override for the deployment cluster above
-  #       namespace: optional override for namespace above
-  #     targetRevision: optional override for targetRevision above
+  #   service: service name as it appears in K8S (statefulset/deployment name).
+  #     destination: optional override for destination parameters above.
+  #       name: optional override for the deployment cluster above.
+  #       namespace: optional override for namespace above.
+  #     serviceChart: optional override for the helm chart to use. 
+  #                 The path is always services/<serviceChart> within the repo.
+  #     targetRevision: optional override for targetRevision above.
   #     repoURL: optional override for git repo to source the helm chart from
-  #            the path is always services/<service> within that repo
+  #            the path is always services/<service> within that repo.
   #     valuesObject: An object that is passed as values to the helm chart.
   #                 This is merged with the default values.yaml in the repo,
   #                 with valuesObject taking precedence.
   #     valuesFiles: A list of paths to values.yaml files that are passed to
   #                 the helm chart. Subsequent files in the list override
   #                 the previous ones.
-  #     removed: set to true to remove the service from the cluster
-  #     enabled: set to false to stop a service
+  #     removed: set to true to remove the service from the cluster.
+  #     enabled: set to false to stop a service.
 
   # @schema type: [object, null]
   example1:
@@ -59,6 +61,10 @@ services:
     # @schema additionalProperties: {"type":"string","maxLength":63,"description":"Custom labels applied to the resource.","pattern":"^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$|^[a-zA-Z0-9]$"}
     # @schema default: {}
     labels: {}
+
+    # @schema type: string
+    # @schema default: ""
+    serviceChart: ""
 
     # @schema type: string
     # @schema default: ""


### PR DESCRIPTION
When working with staging deployments, you will want to be able to use the same helm chart in the services repo, but with different valuesFiles/objects. At present, ec-helm-charts will only reference the helm chart from the name of the service. e.g

```
  gitlab-runners:

  gitlab-runners-dev:
    destination:
      name: pollux
    valuesFiles:
      - values.yaml
      - values-dev.yaml 
```
In this example, both service apps will want to point to services/gitlab-runners chart in the services repo, but the later entry will instead try to find services/gitlab-runners-dev chart and fail.

This PR adds a serviceChart override to the settings to be able to specify when the name of the service does not match the chart you wish to deploy from. If no entry is given, it will default to the name of the service (previous behaviour).

The configuration would then look like this:

```
  gitlab-runners:

  gitlab-runners-dev:
    serviceChart: gitlab-runners
    destination:
      name: pollux
    valuesFiles:
      - values.yaml
      - values-dev.yaml 
```

Tested in version 5.5.0-beta.10