### PR TITLE
Auto rct

### DIFF
--- a/Charts/ioc-instance/example.values.yaml
+++ b/Charts/ioc-instance/example.values.yaml
@@ -20,3 +20,10 @@ ioc-instance:
         - sleep
       args: # @schema required
         - "3600" # sleep for an hour
+
+  usbDevices:
+    - vendor: "04d8" # @schema description: USB vendor ID
+      product: "00a3" # @schema description: USB product ID
+      serial: "ABC123" # @schema description: Serial number
+      host: "10.12.34.5" # @schema description: Host IP
+      bus: "1-2.3" # @schema description: USB bus path

--- a/Charts/ioc-instance/ioc-instance.schema.json
+++ b/Charts/ioc-instance/ioc-instance.schema.json
@@ -307,6 +307,10 @@
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/podspec.json#/properties/tolerations",
                     "type": "array"
                 },
+                "usbDevices": {
+                    "description": "declare usb devices to attach to pod using dynamic resource allocation.",
+                    "type": "array"
+                },
                 "volumeMounts": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/volumeMounts",
                     "type": "array"

--- a/Charts/ioc-instance/ioc-instance.schema.json
+++ b/Charts/ioc-instance/ioc-instance.schema.json
@@ -308,8 +308,35 @@
                     "type": "array"
                 },
                 "usbDevices": {
-                    "description": "declare usb devices to attach to pod using dynamic resource allocation.",
-                    "type": "array"
+                    "description": "declare usb devices to attach to pod using dynamic resource allocation. Requires Kubernetes \u003e=1.34 (DRA GA). Values must not contain '\"' or '\\'.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "bus": {
+                                "description": "USB bus path",
+                                "type": "string"
+                            },
+                            "host": {
+                                "description": "Host IP",
+                                "type": "string"
+                            },
+                            "product": {
+                                "description": "USB product ID",
+                                "type": "string"
+                            },
+                            "serial": {
+                                "description": "Serial number",
+                                "type": "string"
+                            },
+                            "vendor": {
+                                "description": "USB vendor ID",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "additionalProperties": false
                 },
                 "volumeMounts": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.3/container.json#/properties/volumeMounts",

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -1,4 +1,5 @@
 {{ define "ioc-instance" }}
+
 {{- include "ioc-instance.configmap" . }}
 ---
 {{ include "ioc-instance.statefulset" . }}
@@ -6,5 +7,11 @@
 {{ include "ioc-instance.service" . }}
 ---
 {{ include "ioc-instance.datavolume" . }}
-{{ include "ioc-instance.resourceclaimtemplate" . }}
+
+{{- with get .Values "ioc-instance" }}
+{{- if .usbDevices }}
+{{ include "ioc-instance.resourceclaimtemplate" $ }}
+{{- end }}
+{{- end }}
+
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -6,8 +6,5 @@
 {{ include "ioc-instance.service" . }}
 ---
 {{ include "ioc-instance.datavolume" . }}
-{{- if .usbDevices }}
----
 {{ include "ioc-instance.resourceclaimtemplate" . }}
-{{- end }}
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -8,10 +8,10 @@
 ---
 {{ include "ioc-instance.datavolume" . }}
 
-{{/* {{- with get .Values "ioc-instance" }}
+{{- with get .Values "ioc-instance" }}
 {{- if .usbDevices }}
 {{ include "ioc-instance.resourceclaimtemplate" $ }}
 {{- end }}
-{{- end }} */}}
+{{- end }}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -8,10 +8,10 @@
 ---
 {{ include "ioc-instance.datavolume" . }}
 
-{{- with get .Values "ioc-instance" }}
+{{/* {{- with get .Values "ioc-instance" }}
 {{- if .usbDevices }}
 {{ include "ioc-instance.resourceclaimtemplate" $ }}
 {{- end }}
-{{- end }}
+{{- end }} */}}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -8,10 +8,6 @@
 ---
 {{ include "ioc-instance.datavolume" . }}
 
-{{- with get .Values "ioc-instance" }}
-{{- if .usbDevices }}
-{{ include "ioc-instance.resourceclaimtemplate" $ }}
-{{- end }}
-{{- end }}
+{{- include "ioc-instance.resourceclaimtemplate" $ }}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -8,6 +8,6 @@
 ---
 {{ include "ioc-instance.datavolume" . }}
 
-{{- include "ioc-instance.resourceclaimtemplate" $ }}
+{{- include "ioc-instance.resourceclaimtemplate" . }}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -7,5 +7,7 @@
 {{ include "ioc-instance.service" . }}
 ---
 {{ include "ioc-instance.datavolume" . }}
+---
+{{ include "ioc-instance.resourceclaimtemplate" . }}
 
 {{- end }}

--- a/Charts/ioc-instance/templates/_iocInstance.tpl
+++ b/Charts/ioc-instance/templates/_iocInstance.tpl
@@ -1,5 +1,4 @@
 {{ define "ioc-instance" }}
-
 {{- include "ioc-instance.configmap" . }}
 ---
 {{ include "ioc-instance.statefulset" . }}
@@ -7,7 +6,8 @@
 {{ include "ioc-instance.service" . }}
 ---
 {{ include "ioc-instance.datavolume" . }}
+{{- if .usbDevices }}
 ---
 {{ include "ioc-instance.resourceclaimtemplate" . }}
-
+{{- end }}
 {{- end }}

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -7,24 +7,14 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
 
 {{- $usbKey := $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 
+{{- range $i, $device := .usbDevices }}
 
-{{- range $device := .usbDevices }}
-
-{{- /* --- validate - must have name and at least one selector attribute --- */ -}}
-{{- $attrKeys := list -}}
-{{- range $key, $_ := $device -}}
-  {{- if ne $key "name" -}}
-    {{- $attrKeys = append $attrKeys $key -}}
-  {{- end -}}
-{{- end -}}
-{{- if eq (len $attrKeys) 0 -}}
-  {{- fail (printf "ERROR - usbDevices entry '%s' must have at least one selector attribute [vendor, product, serial, host, bus]" $device.name) -}}
-{{- end }}
+{{- $attrKeys := keys $device | sortAlpha }}
 ---
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
-  name: {{ $device.name }}
+  name: {{ $.Release.Name }}-usb-{{ printf "%02d" (add1 $i) }}
 spec:
   spec:
     devices:

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -21,7 +21,7 @@ spec:
     devices:
       requests:
       - name: req-0
-        firstAvailable:
+        exactly:
         - name: device-0
           deviceClassName: usbip
           allocationMode: ExactCount

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -5,10 +5,8 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
 
 {{ with get .Values "ioc-instance" }}
 
-{{- $usbKey := "" -}}
-{{- if .usbDevices -}}
-  {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
-{{- end -}}
+{{- $usbKey := $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
+
 
 {{- range $device := .usbDevices }}
 

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -31,7 +31,7 @@ spec:
             - cel:
                 expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $device $key }}\""
             {{- end }}
-{{- end }}
+{{- end }} {{/* end range $i, $device := .usbDevices */}}
 {{- end }} {{/* end if .usbDevices */}}
 {{- end }} {{/* end with .ioc-instance */}}
-{{- end -}}
+{{- end }} {{/* end define ioc-instance.resourceclaimtemplate */}}

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -3,6 +3,8 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
 */ -}}
 {{- define "ioc-instance.resourceclaimtemplate" -}}
 
+{{ with get .Values "ioc-instance" }}
+
 {{- $usbKey := "" -}}
 {{- if .usbDevices -}}
   {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
@@ -41,5 +43,5 @@ spec:
                 expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $device $key }}\""
             {{- end }}
 {{- end }}
-
+{{- end }}
 {{- end -}}

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -22,7 +22,6 @@ spec:
       requests:
       - name: req-0
         exactly:
-          name: device-0
           deviceClassName: usbip
           allocationMode: ExactCount
           count: 1

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -40,7 +40,7 @@ spec:
           selectors:
             {{- range $key := ($attrKeys | sortAlpha) }}
             - cel:
-                expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $dev $key }}\""
+                expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $device $key }}\""
             {{- end }}
 {{- end }}
 

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -18,13 +18,13 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
   {{- end -}}
 {{- end -}}
 {{- if eq (len $attrKeys) 0 -}}
-  {{- fail (printf "ERROR - usbDevices entry '%s' must have at least one selector attribute (vendor, product, serial, etc.)" $device.name) -}}
+  {{- fail (printf "ERROR - usbDevices entry '%s' must have at least one selector attribute [vendor, product, serial, host, bus]" $device.name) -}}
 {{- end }}
 ---
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
-  name: rct-{{ $dev.name }}
+  name: {{ $device.name }}
   labels:
     {{- include "ioc-instance.labels" $ | nindent 4 }}
 spec:
@@ -33,7 +33,7 @@ spec:
       requests:
       - name: req-0
         firstAvailable:
-        - name: {{ $dev.name }}
+        - name: device-0
           deviceClassName: usbip
           allocationMode: ExactCount
           count: 1

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -1,0 +1,47 @@
+{{- /*
+ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTemplate per entry in .usbDevices.
+*/ -}}
+{{- define "ioc-instance.resourceclaimtemplate" -}}
+
+{{- $usbKey := "" -}}
+{{- if .usbDevices -}}
+  {{- $usbKey = .Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
+{{- end -}}
+
+{{- range $device := .usbDevices }}
+
+{{- /* --- validate - must have name and at least one selector attribute --- */ -}}
+{{- $attrKeys := list -}}
+{{- range $key, $_ := $device -}}
+  {{- if ne $key "name" -}}
+    {{- $attrKeys = append $attrKeys $key -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq (len $attrKeys) 0 -}}
+  {{- fail (printf "ERROR - usbDevices entry '%s' must have at least one selector attribute (vendor, product, serial, etc.)" $device.name) -}}
+{{- end }}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-{{ $dev.name }}
+  labels:
+    {{- include "ioc-instance.labels" $ | nindent 4 }}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-0
+        firstAvailable:
+        - name: {{ $dev.name }}
+          deviceClassName: usbip
+          allocationMode: ExactCount
+          count: 1
+          selectors:
+            {{- range $key := ($attrKeys | sortAlpha) }}
+            - cel:
+                expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $dev $key }}\""
+            {{- end }}
+{{- end }}
+
+{{- end -}}

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -5,7 +5,7 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
 
 {{- $usbKey := "" -}}
 {{- if .usbDevices -}}
-  {{- $usbKey = .Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
+  {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 {{- end -}}
 
 {{- range $device := .usbDevices }}
@@ -25,8 +25,6 @@ apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
   name: {{ $device.name }}
-  labels:
-    {{- include "ioc-instance.labels" $ | nindent 4 }}
 spec:
   spec:
     devices:

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -4,6 +4,7 @@ ResourceClaimTemplate generation for USB devices. Generates one ResourceClaimTem
 {{- define "ioc-instance.resourceclaimtemplate" -}}
 
 {{ with get .Values "ioc-instance" }}
+{{- if .usbDevices }}
 
 {{- $usbKey := $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 
@@ -26,10 +27,11 @@ spec:
           allocationMode: ExactCount
           count: 1
           selectors:
-            {{- range $key := ($attrKeys | sortAlpha) }}
+            {{- range $key := $attrKeys }}
             - cel:
                 expression: "device.attributes[\"{{ $usbKey }}\"].{{ $key }} == \"{{ index $device $key }}\""
             {{- end }}
 {{- end }}
-{{- end }}
+{{- end }} {{/* end if .usbDevices */}}
+{{- end }} {{/* end with .ioc-instance */}}
 {{- end -}}

--- a/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
+++ b/Charts/ioc-instance/templates/_resourceclaimtemplate.tpl
@@ -22,7 +22,7 @@ spec:
       requests:
       - name: req-0
         exactly:
-        - name: device-0
+          name: device-0
           deviceClassName: usbip
           allocationMode: ExactCount
           count: 1

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,15 +1,14 @@
 {{- define "ioc-instance.service" -}}
+
 {{/*
   Use with to access ioc-instance key.
   Required because .ioc-instance is illegal because of the hyphen.
 */}}
-# when not using hostNetwork, create a service to give the IOC a fixed cluster IP
-# TODO - we could introduce this service to hostNetwork IOCs too: for review.
-
-{{- if not .hostNetwork }}
-
 {{ with get .Values "ioc-instance" }}
 
+# when not using hostNetwork, create a service to give the IOC a fixed cluster IP
+# TODO - we could introduce this service to hostNetwork IOCs too: for review.
+{{- if not .hostNetwork }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,7 +1,5 @@
 {{- define "ioc-instance.service" -}}
 
-{{- if not .hostNetwork }}
-
 {{/*
   Use with to access ioc-instance key.
   Required because .ioc-instance is illegal because of the hyphen.
@@ -10,7 +8,7 @@
 
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
 # TODO - we could introduce this service to hostNetwork IOCs too: for review.
-
+{{- if not .hostNetwork }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,14 +1,15 @@
 {{- define "ioc-instance.service" -}}
-
 {{/*
   Use with to access ioc-instance key.
   Required because .ioc-instance is illegal because of the hyphen.
 */}}
-{{ with get .Values "ioc-instance" }}
-
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
 # TODO - we could introduce this service to hostNetwork IOCs too: for review.
+
 {{- if not .hostNetwork }}
+
+{{ with get .Values "ioc-instance" }}
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/Charts/ioc-instance/templates/_service.tpl
+++ b/Charts/ioc-instance/templates/_service.tpl
@@ -1,5 +1,7 @@
 {{- define "ioc-instance.service" -}}
 
+{{- if not .hostNetwork }}
+
 {{/*
   Use with to access ioc-instance key.
   Required because .ioc-instance is illegal because of the hyphen.
@@ -8,7 +10,7 @@
 
 # when not using hostNetwork, create a service to give the IOC a fixed cluster IP
 # TODO - we could introduce this service to hostNetwork IOCs too: for review.
-{{- if not .hostNetwork }}
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -109,13 +109,13 @@ spec:
       {{- end }}
 
       {{- /* resource claims ************************************************/}}
-      {{- with .usbDevices }}
+      {{/* {{- with .usbDevices }}
       resourceClaims:
         {{- range $device := . }}
         - name: {{ $device.name }}
           resourceClaimTemplateName: {{ $device.name }}
         {{- end }}
-      {{- end }}
+      {{- end }} */}}
 
       {{- /* volumes ********************************************************/}}
       volumes:
@@ -271,12 +271,12 @@ spec:
         {{- with .resources }}
         resources:
           {{- toYaml . | nindent 10 }}
-          {{- with $usbDevices }}
+          {{/* {{- with $usbDevices }}
           claims:
             {{- range $device := . }}
             - name: {{ $device.name }}
             {{- end }}
-          {{- end }}
+          {{- end }} */}}
         {{- end }}
         env: &env
         - name: ARGOCD_SOURCE_REPO

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -27,9 +27,9 @@ to a minimum
 {{- /* --- USB device key: required when usbDevices are declared --- */ -}}
 {{- $usbKey := "" -}}
 {{- if .usbDevices -}}
-  {{- $usbKey = .Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
+  {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 {{- else -}}
-  {{- $usbKey = default "" .Values.global.usbKey -}}
+  {{- $usbKey = default "" $.Values.global.usbKey -}}
 {{- end -}}
 
 apiVersion: apps/v1

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -24,6 +24,14 @@ to a minimum
 {{- $enabled := eq $.Values.global.enabled false | ternary false true }}
 {{- $customLabels := $.Values.global.labels }}
 
+{{- /* --- USB device key: required when usbDevices are declared --- */ -}}
+{{- $usbKey := "" -}}
+{{- if .Values.usbDevices -}}
+  {{- $usbKey = .Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
+{{- else -}}
+  {{- $usbKey = default "" .Values.global.usbKey -}}
+{{- end -}}
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -98,6 +106,15 @@ spec:
       {{- with .tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- /* resource claims ************************************************/}}
+      {{- with .usbDevices }}
+      resourceClaims:
+        {{- range $dev := . }}
+        - name: {{ $dev.name }}
+          resourceClaimTemplateName: rct-{{ $dev.name }}
+        {{- end }}
       {{- end }}
 
       {{- /* volumes ********************************************************/}}
@@ -253,6 +270,12 @@ spec:
         {{- with .resources }}
         resources:
           {{- toYaml . | nindent 10 }}
+          {{- with $.usbDevices }}
+          claims:
+            {{- range $dev := . }}
+            - name: {{ $dev.name }}
+            {{- end }}
+          {{- end }}
         {{- end }}
         env: &env
         - name: ARGOCD_SOURCE_REPO

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -111,9 +111,9 @@ spec:
       {{- /* resource claims ************************************************/}}
       {{- with .usbDevices }}
       resourceClaims:
-        {{- range $device := . }}
-        - name: {{ $device.name }}
-          resourceClaimTemplateName: {{ $device.name }}
+        {{- range $i, $device := . }}
+        - name: {{ $.Release.Name }}-usb-{{ printf "%02d" (add1 $i) }}
+          resourceClaimTemplateName: {{ $.Release.Name }}-usb-{{ printf "%02d" (add1 $i) }}
         {{- end }}
       {{- end }}
 
@@ -273,8 +273,8 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- with $usbDevices }}
           claims:
-            {{- range $device := . }}
-            - name: {{ $device.name }}
+            {{- range $i, $device := . }}
+            - name: {{ $.Release.Name }}-usb-{{ printf "%02d" (add1 $i) }}
             {{- end }}
           {{- end }}
         {{- end }}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -24,13 +24,6 @@ to a minimum
 {{- $enabled := eq $.Values.global.enabled false | ternary false true }}
 {{- $customLabels := $.Values.global.labels }}
 
-{{- /* --- USB device key: required when usbDevices are declared --- */ -}}
-{{- $usbKey := "" -}}
-{{- if .usbDevices -}}
-  {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
-{{- else -}}
-  {{- $usbKey = default "" $.Values.global.usbKey -}}
-{{- end }}
 
 apiVersion: apps/v1
 kind: StatefulSet

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -26,7 +26,7 @@ to a minimum
 
 {{- /* --- USB device key: required when usbDevices are declared --- */ -}}
 {{- $usbKey := "" -}}
-{{- if .Values.usbDevices -}}
+{{- if .usbDevices -}}
   {{- $usbKey = .Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 {{- else -}}
   {{- $usbKey = default "" .Values.global.usbKey -}}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -111,9 +111,9 @@ spec:
       {{- /* resource claims ************************************************/}}
       {{- with .usbDevices }}
       resourceClaims:
-        {{- range $dev := . }}
-        - name: {{ $dev.name }}
-          resourceClaimTemplateName: rct-{{ $dev.name }}
+        {{- range $device := . }}
+        - name: {{ $device.name }}
+          resourceClaimTemplateName: {{ $device.name }}
         {{- end }}
       {{- end }}
 
@@ -272,8 +272,8 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- with $.usbDevices }}
           claims:
-            {{- range $dev := . }}
-            - name: {{ $dev.name }}
+            {{- range $device := . }}
+            - name: {{ $device.name }}
             {{- end }}
           {{- end }}
         {{- end }}

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -30,7 +30,7 @@ to a minimum
   {{- $usbKey = $.Values.global.usbKey | required "ERROR - You must supply global.usbKey when usbDevices are declared" -}}
 {{- else -}}
   {{- $usbKey = default "" $.Values.global.usbKey -}}
-{{- end -}}
+{{- end }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -109,13 +109,13 @@ spec:
       {{- end }}
 
       {{- /* resource claims ************************************************/}}
-      {{/* {{- with .usbDevices }}
+      {{- with .usbDevices }}
       resourceClaims:
         {{- range $device := . }}
         - name: {{ $device.name }}
           resourceClaimTemplateName: {{ $device.name }}
         {{- end }}
-      {{- end }} */}}
+      {{- end }}
 
       {{- /* volumes ********************************************************/}}
       volumes:
@@ -271,12 +271,12 @@ spec:
         {{- with .resources }}
         resources:
           {{- toYaml . | nindent 10 }}
-          {{/* {{- with $usbDevices }}
+          {{- with $usbDevices }}
           claims:
             {{- range $device := . }}
             - name: {{ $device.name }}
             {{- end }}
-          {{- end }} */}}
+          {{- end }}
         {{- end }}
         env: &env
         - name: ARGOCD_SOURCE_REPO

--- a/Charts/ioc-instance/templates/_statefulset.tpl
+++ b/Charts/ioc-instance/templates/_statefulset.tpl
@@ -267,10 +267,11 @@ spec:
         securityContext:
           {{-  toYaml . | nindent 10 }}
         {{- end }}
+        {{- $usbDevices := .usbDevices }}
         {{- with .resources }}
         resources:
           {{- toYaml . | nindent 10 }}
-          {{- with $.usbDevices }}
+          {{- with $usbDevices }}
           claims:
             {{- range $device := . }}
             - name: {{ $device.name }}

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -150,6 +150,9 @@ ioc-instance:
       cpu: 100m
       memory: 64Mi
 
+  # @schema description: declare usb devices to attach to pod using dynamic resource allocation.
+  usbDevices: []
+
   # @schema description: supply a fixed cluster IP for the service
   clusterIP:
 

--- a/Charts/ioc-instance/values.yaml
+++ b/Charts/ioc-instance/values.yaml
@@ -150,7 +150,8 @@ ioc-instance:
       cpu: 100m
       memory: 64Mi
 
-  # @schema description: declare usb devices to attach to pod using dynamic resource allocation.
+  # @schema description: declare usb devices to attach to pod using dynamic resource allocation. Requires Kubernetes >=1.34 (DRA GA). Values must not contain '"' or '\'.
+  # @schema additionalProperties: false
   usbDevices: []
 
   # @schema description: supply a fixed cluster IP for the service


### PR DESCRIPTION
note: i suggested some changes i already plan in the comments, but want to discuss now that its working

in service values.yaml

```
usbDevices:
    name:
    selector1:
    ...
```

now defines all resourceclaimtemplates, resourceclaims, and resources which are autogenerated in the charts.

working example:
b01-1-beamline/bl01c-ea-flip-01

there is now always one resourceclaimtemplate per device
it lives inside the service

<img width="789" height="459" alt="Screenshot from 2026-05-08 14-39-42" src="https://github.com/user-attachments/assets/8692164b-84cf-408f-8f67-1568a5e73434" />

